### PR TITLE
Add anonymous /say command and ID obfuscation utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ gamerpal/
 │   │   ├── help.go        # Help command
 │   │   ├── ping.go        # Ping command
 │   │   ├── prune.go       # Prune inactive users command
+│   │   ├── say.go         # Anonymous message command
 │   │   └── userstats.go   # User statistics command
 │   ├── config/            # Configuration management
 │   │   ├── config.go      # Configuration loading
@@ -51,6 +52,7 @@ TODO
 | `/userstats` | Shows member counts, growth metrics, and regional breakdown | Admin roles or Administrator permission |
 | `/ping` | Check if the bot is responsive | Admin roles or Administrator permission |
 | `/prune-inactive` | Remove users without any roles (dry run by default) | Administrator permission |
+| `/say` | Send an anonymous message to a specified channel | Administrator permission |
 | `/help` | Display all available commands | Admin roles or Administrator permission |
 
 ## Quick Start

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -71,8 +71,10 @@ func (b *Bot) Start() error {
 	signal.Notify(sc, syscall.SIGINT, syscall.SIGTERM, os.Interrupt)
 	<-sc
 
-	// Cleanup: Unregister commands
-	b.handler.UnregisterCommands(b.session)
+	// Cleanup: Unregister commands, optionally
+	if os.Getenv("UNREGISTER_COMMANDS") == "true" {
+		b.handler.UnregisterCommands(b.session)
+	}
 
 	return nil
 }

--- a/internal/commands/game_test.go
+++ b/internal/commands/game_test.go
@@ -343,8 +343,7 @@ func TestHandlerCreation(t *testing.T) {
 
 		assert.NotNil(t, handler)
 		assert.NotNil(t, handler.igdbClient)
-		assert.NotNil(t, handler.commands)
-		assert.Equal(t, 0, len(handler.commands))
+		assert.NotNil(t, handler.Commands)
 	})
 }
 

--- a/internal/commands/help.go
+++ b/internal/commands/help.go
@@ -47,6 +47,11 @@ func (h *Handler) handleHelp(s *discordgo.Session, i *discordgo.InteractionCreat
 				Inline: false,
 			},
 			{
+				Name:   "/say",
+				Value:  "Send an anonymous message to a specified channel\n• Use `/say channel:#general message:Hello everyone!` to send a message",
+				Inline: false,
+			},
+			{
 				Name:   "/userstats",
 				Value:  "Shows the number of users in the server (excluding bots)",
 				Inline: false,

--- a/internal/commands/say.go
+++ b/internal/commands/say.go
@@ -1,0 +1,148 @@
+package commands
+
+import (
+	"fmt"
+	"gamerpal/internal/utils"
+
+	"github.com/bwmarrin/discordgo"
+)
+
+// handleSay handles the say slash command
+func (h *Handler) handleSay(s *discordgo.Session, i *discordgo.InteractionCreate) {
+	// Parse command options
+	options := i.ApplicationCommandData().Options
+	if len(options) < 2 {
+		s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+			Type: discordgo.InteractionResponseChannelMessageWithSource,
+			Data: &discordgo.InteractionResponseData{
+				Content: "❌ Missing required parameters. Please specify both channel and message.",
+				Flags:   discordgo.MessageFlagsEphemeral,
+			},
+		})
+		return
+	}
+
+	// Get channel and message from options
+	var targetChannelID string
+	var messageContent string
+
+	for _, option := range options {
+		switch option.Name {
+		case "channel":
+			targetChannelID = option.ChannelValue(s).ID
+		case "message":
+			messageContent = option.StringValue()
+		}
+	}
+
+	// Validate inputs
+	if targetChannelID == "" {
+		s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+			Type: discordgo.InteractionResponseChannelMessageWithSource,
+			Data: &discordgo.InteractionResponseData{
+				Content: "❌ Invalid channel specified.",
+				Flags:   discordgo.MessageFlagsEphemeral,
+			},
+		})
+		return
+	}
+
+	if messageContent == "" {
+		s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+			Type: discordgo.InteractionResponseChannelMessageWithSource,
+			Data: &discordgo.InteractionResponseData{
+				Content: "❌ Message content cannot be empty.",
+				Flags:   discordgo.MessageFlagsEphemeral,
+			},
+		})
+		return
+	}
+
+	// Get the target channel to verify it exists and get its name
+	targetChannel, err := s.Channel(targetChannelID)
+	if err != nil {
+		s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+			Type: discordgo.InteractionResponseChannelMessageWithSource,
+			Data: &discordgo.InteractionResponseData{
+				Content: "❌ Unable to access the specified channel. Make sure the bot has permission to view and send messages in that channel.",
+				Flags:   discordgo.MessageFlagsEphemeral,
+			},
+		})
+		return
+	}
+
+	// Check if the bot has permission to send messages in the target channel
+	permissions, err := s.UserChannelPermissions(s.State.User.ID, targetChannelID)
+	if err != nil || permissions&discordgo.PermissionSendMessages == 0 {
+		s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+			Type: discordgo.InteractionResponseChannelMessageWithSource,
+			Data: &discordgo.InteractionResponseData{
+				Content: fmt.Sprintf("❌ I don't have permission to send messages in %s.", targetChannel.Mention()),
+				Flags:   discordgo.MessageFlagsEphemeral,
+			},
+		})
+		return
+	}
+
+	// Add the anonymous admin tag to the message content to distinguish
+	// different admins anonymously.
+	anonID, err := utils.ObfuscateID(i.Member.User.ID, h.CryptoSalt)
+	if err != nil {
+		s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+			Type: discordgo.InteractionResponseChannelMessageWithSource,
+			Data: &discordgo.InteractionResponseData{
+				Content: "❌ Failed to obfuscate your ID. Please try again later.",
+				Flags:   discordgo.MessageFlagsEphemeral,
+			},
+		})
+		return
+	}
+
+	messageContent = fmt.Sprintf("%s\n\n**Sent by mod (%s)**", messageContent, anonID)
+
+	// Send the message to the target channel
+	sentMessage, err := s.ChannelMessageSend(targetChannelID, messageContent)
+	if err != nil {
+		s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+			Type: discordgo.InteractionResponseChannelMessageWithSource,
+			Data: &discordgo.InteractionResponseData{
+				Content: fmt.Sprintf("❌ Failed to send message to %s: %v", targetChannel.Mention(), err),
+				Flags:   discordgo.MessageFlagsEphemeral,
+			},
+		})
+		return
+	}
+
+	// Create confirmation embed for the admin
+	embed := &discordgo.MessageEmbed{
+		Title:       "✅ Message Sent Successfully",
+		Description: fmt.Sprintf("Your anonymous message has been sent to %s", targetChannel.Mention()),
+		Color:       utils.Colors.Ok(),
+		Fields: []*discordgo.MessageEmbedField{
+			{
+				Name:   "Channel",
+				Value:  targetChannel.Mention(),
+				Inline: true,
+			},
+			{
+				Name:   "Message ID",
+				Value:  sentMessage.ID,
+				Inline: true,
+			},
+			{
+				Name:   "Message Content",
+				Value:  fmt.Sprintf("```%s```", messageContent),
+				Inline: false,
+			},
+		},
+	}
+
+	// Respond to the admin with confirmation (ephemeral)
+	s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+		Type: discordgo.InteractionResponseChannelMessageWithSource,
+		Data: &discordgo.InteractionResponseData{
+			Embeds: []*discordgo.MessageEmbed{embed},
+			Flags:  discordgo.MessageFlagsEphemeral,
+		},
+	})
+}

--- a/internal/utils/members.go
+++ b/internal/utils/members.go
@@ -1,6 +1,9 @@
 package utils
 
 import (
+	"fmt"
+	"hash/fnv"
+
 	"github.com/bwmarrin/discordgo"
 )
 
@@ -24,4 +27,68 @@ func GetAllGuildMembers(s *discordgo.Session, guildID string) ([]*discordgo.Memb
 	}
 
 	return allMembers, nil
+}
+
+// ObfuscateID generates an obfuscated version of a Discord user ID
+func ObfuscateID(userID string, salt string) (string, error) {
+	if userID == "" || salt == "" {
+		return "", fmt.Errorf("Failed to read salt or something, IDK. Someone should fix it.")
+	}
+
+	nouns := []string{
+		"Cucumber",
+		"Tomato",
+		"Banana",
+		"Apple",
+		"Orange",
+		"Strawberry",
+		"Blueberry",
+		"Raspberry",
+		"Kiwi",
+		"Peach",
+		"Plum",
+		"Melon",
+		"Grape",
+		"Cherry",
+		"Papaya",
+		"Mango",
+		"Watermelon",
+	}
+
+	adjectives := []string{
+		"Shiny",
+		"Juicy",
+		"Sweet",
+		"Tasty",
+		"Fresh",
+		"Ripe",
+		"Delicious",
+		"Colorful",
+		"Vibrant",
+		"Exotic",
+		"Delightful",
+		"Succulent",
+		"Zesty",
+		"Fragrant",
+		"Flavorful",
+		"Refreshing",
+		"Tropical",
+	}
+
+	// This isn't the most secure, but should be sufficient for obfuscation.
+	// Someone really serious could still reverse engineer it.
+
+	// Use the salt to create a hash within the range of nouns
+	hash := fnv.New32a()
+	hash.Write([]byte(salt))
+	hash.Write([]byte(userID))
+	noun := nouns[hash.Sum32()%uint32(len(nouns))]
+
+	// Use the salt to create a hash within the range of adjectives
+	hash.Reset()
+	hash.Write([]byte(salt))
+	hash.Write([]byte(userID))
+	adjective := adjectives[hash.Sum32()%uint32(len(adjectives))]
+
+	return fmt.Sprintf("%s %s", adjective, noun), nil
 }

--- a/internal/utils/members_test.go
+++ b/internal/utils/members_test.go
@@ -1,0 +1,68 @@
+package utils
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestObfuscateID(t *testing.T) {
+	tests := []struct {
+		name    string
+		userID  string
+		salt    string
+		wantErr bool
+	}{
+		{
+			name:    "valid inputs",
+			userID:  "123456789",
+			salt:    "mysalt",
+			wantErr: false,
+		},
+		{
+			name:    "empty userID",
+			userID:  "",
+			salt:    "mysalt",
+			wantErr: true,
+		},
+		{
+			name:    "empty salt",
+			userID:  "123456789",
+			salt:    "",
+			wantErr: true,
+		},
+		{
+			name:    "both empty",
+			userID:  "",
+			salt:    "",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := ObfuscateID(tt.userID, tt.salt)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+
+			// Check format is "noun-adjective"
+			parts := strings.Split(result, " ")
+			require.Len(t, parts, 2, "Obfuscated ID should be in the format 'noun-adjective'")
+		})
+	}
+}
+
+func TestObfuscateID_DifferentInputs(t *testing.T) {
+	salt := "testsalt"
+
+	result1, _ := ObfuscateID("user1", salt)
+	result2, _ := ObfuscateID("user2", salt)
+
+	require.NotEqual(t, result1, result2, "Obfuscated IDs should be different for different user IDs")
+}


### PR DESCRIPTION
Introduces the /say command for admins to send anonymous messages to specified channels, with sender identity obfuscated using a new utility function. Updates command registration, help text, and adds tests for the obfuscation logic. Also improves command cleanup and welcome command options.