### PR TITLE
Add daily and overview options to user stats command

### DIFF
--- a/internal/commands/handler.go
+++ b/internal/commands/handler.go
@@ -73,6 +73,24 @@ func NewHandler(cfg *config.Config) *Handler {
 				Description:              "Show member statistics for the server",
 				Contexts:                 &[]discordgo.InteractionContextType{discordgo.InteractionContextGuild},
 				DefaultMemberPermissions: &modPerms,
+				Options: []*discordgo.ApplicationCommandOption{
+					{
+						Type:        discordgo.ApplicationCommandOptionString,
+						Name:        "stats",
+						Description: "Which statistics to show",
+						Required:    false,
+						Choices: []*discordgo.ApplicationCommandOptionChoice{
+							{
+								Name:  "Overview",
+								Value: "overview",
+							},
+							{
+								Name:  "Daily (Last 7 Days)",
+								Value: "daily",
+							},
+						},
+					},
+				},
 			},
 			HandlerFunc: h.handleUserStats,
 		},


### PR DESCRIPTION
Introduces a 'stats' option to the user stats command, allowing users to select between 'Overview' and 'Daily (Last 7 Days)' statistics. Implements separate handlers for overview and daily statistics, with daily stats showing new member joins for each of the last 7 days.