### PR TITLE
Add support ticket transcript generation on close

### DIFF
--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -359,7 +359,7 @@ func generateChannelTranscript(messages []*discordgo.Message, channelName string
 			if len(msg.Mentions) != 0 {
 				for _, mention := range msg.Mentions {
 					// Replace mentions with usernames
-					msgContent = strings.ReplaceAll(msgContent, mention.Mention(), mention.Username)
+					msgContent = strings.ReplaceAll(msgContent, mention.Mention(), fmt.Sprintf("%s (%s)", mention.GlobalName, mention.Username))
 				}
 			}
 

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -354,8 +354,17 @@ func generateChannelTranscript(messages []*discordgo.Message, channelName string
 
 		// Handle different message types
 		if msg.Type == discordgo.MessageTypeDefault || msg.Type == discordgo.MessageTypeReply {
+
+			msgContent := msg.Content
+			if len(msg.Mentions) != 0 {
+				for _, mention := range msg.Mentions {
+					// Replace mentions with usernames
+					msgContent = strings.ReplaceAll(msgContent, mention.Mention(), mention.Username)
+				}
+			}
+
 			transcript.WriteString(fmt.Sprintf("[%s] %s: %s\n",
-				timestamp, msg.Author.GlobalName, msg.Content))
+				timestamp, msg.Author.GlobalName, msgContent))
 
 			// Include attachments if any
 			if len(msg.Attachments) > 0 {

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -1,11 +1,13 @@
 package bot
 
 import (
+	"bytes"
 	"fmt"
 	"log"
 	"math/rand/v2"
 	"os"
 	"os/signal"
+	"sort"
 	"strings"
 	"syscall"
 	"time"
@@ -170,17 +172,22 @@ func (b *Bot) onChannelUpdate(s *discordgo.Session, c *discordgo.ChannelUpdate) 
 }
 
 func handleSupportTicketClose(s *discordgo.Session, c *discordgo.ChannelUpdate, cfg *config.Config) {
-	// Get the channel messages
-	messages, err := s.ChannelMessages(c.ID, 100, "", "", "")
+	// Get all channel messages using pagination
+	allMessages, err := getAllChannelMessages(s, c.ID)
 	if err != nil {
 		log.Printf("Error getting channel messages: %v", err)
 		return
 	}
 
+	// Sort messages by timestamp (oldest first)
+	sort.Slice(allMessages, func(i, j int) bool {
+		return allMessages[i].Timestamp.Before(allMessages[j].Timestamp)
+	})
+
 	var userPrompt strings.Builder
 
 	userPrompt.WriteString("ticket number: " + c.Name + "\n\n")
-	for _, msg := range messages {
+	for _, msg := range allMessages {
 		if msg.Author.ID == s.State.User.ID {
 			userPrompt.WriteString(fmt.Sprintf("%s (on behalf of mod): %s\n", msg.Author.Username, msg.Content))
 			continue
@@ -229,6 +236,11 @@ func handleSupportTicketClose(s *discordgo.Session, c *discordgo.ChannelUpdate, 
 
 	log.Println("Generated summary:", summary)
 
+	// Generate channel transcript
+	transcript := generateChannelTranscript(allMessages, c.Name)
+
+	responseChannel := cfg.GetGamerPalsModActionLogChannelID()
+
 	// Create embed message
 	embed := &discordgo.MessageEmbed{
 		Title:       "🎫 Support Ticket Closed",
@@ -236,13 +248,18 @@ func handleSupportTicketClose(s *discordgo.Session, c *discordgo.ChannelUpdate, 
 		Color:       0x00ff00, // Green color
 		Fields: []*discordgo.MessageEmbedField{
 			{
-				Name:   " Closed At",
+				Name:   "⏰ Closed At",
 				Value:  time.Now().Format("January 2, 2006 at 3:04 PM MST"),
 				Inline: true,
 			},
 			{
 				Name:   "🔗 Channel",
 				Value:  fmt.Sprintf("<#%s>", c.ID),
+				Inline: true,
+			},
+			{
+				Name:   "📄 Messages",
+				Value:  fmt.Sprintf("%d total messages", len(allMessages)),
 				Inline: true,
 			},
 		},
@@ -252,13 +269,10 @@ func handleSupportTicketClose(s *discordgo.Session, c *discordgo.ChannelUpdate, 
 		},
 	}
 
-	responseChannel := cfg.GetGamerPalsModActionLogChannelID()
-
 	// Send the embed first
 	_, err = s.ChannelMessageSendEmbed(responseChannel, embed)
 	if err != nil {
 		log.Printf("Error sending embed message to channel %s: %v", responseChannel, err)
-		return
 	}
 
 	// Send in batches of 1500 characters
@@ -271,7 +285,129 @@ func handleSupportTicketClose(s *discordgo.Session, c *discordgo.ChannelUpdate, 
 		_, err = s.ChannelMessageSend(responseChannel, part)
 		if err != nil {
 			log.Printf("Error sending summary part to channel %s: %v", responseChannel, err)
-			return
+			continue
 		}
+	}
+
+	// Send the remaining summary if any
+	if len(summary) > 0 {
+		_, err = s.ChannelMessageSend(responseChannel, summary)
+		if err != nil {
+			log.Printf("Error sending final summary part to channel %s: %v", responseChannel, err)
+		}
+	}
+
+	// Send the transcript as an attachment
+	transcriptFileName := fmt.Sprintf("transcript_%s_%s.txt", c.Name, time.Now().Format("2006-01-02_15-04-05"))
+
+	messageData := &discordgo.MessageSend{
+		Content: "📄 **Channel Transcript Attached**",
+		Files: []*discordgo.File{
+			{
+				Name:        transcriptFileName,
+				ContentType: "text/plain",
+				Reader:      transcript,
+			},
+		},
+	}
+
+	_, err = s.ChannelMessageSendComplex(responseChannel, messageData)
+	if err != nil {
+		log.Printf("Error sending transcript attachment to channel %s: %v", responseChannel, err)
+	}
+
+	log.Printf("Successfully processed closed ticket %s and sent transcript", c.Name)
+}
+
+// getAllChannelMessages fetches all messages from a channel using pagination
+func getAllChannelMessages(s *discordgo.Session, channelID string) ([]*discordgo.Message, error) {
+	var allMessages []*discordgo.Message
+	var beforeID string
+	const limit = 100
+
+	for {
+		messages, err := s.ChannelMessages(channelID, limit, beforeID, "", "")
+		if err != nil {
+			return nil, fmt.Errorf("error fetching messages: %w", err)
+		}
+
+		if len(messages) == 0 {
+			break
+		}
+
+		allMessages = append(allMessages, messages...)
+		beforeID = messages[len(messages)-1].ID
+
+		// If we got fewer messages than the limit, we've reached the end
+		if len(messages) < limit {
+			break
+		}
+
+		// Add a small delay to avoid rate limiting
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	return allMessages, nil
+}
+
+// generateChannelTranscript creates a formatted transcript of all channel messages
+func generateChannelTranscript(messages []*discordgo.Message, channelName string) *bytes.Buffer {
+	var transcript bytes.Buffer
+
+	transcript.WriteString(fmt.Sprintf("Channel Transcript: %s\n", channelName))
+	transcript.WriteString(fmt.Sprintf("Generated on: %s\n", time.Now().Format("January 2, 2006 at 3:04 PM MST")))
+	transcript.WriteString(fmt.Sprintf("Total messages: %d\n", len(messages)))
+	transcript.WriteString(strings.Repeat("=", 80) + "\n\n")
+
+	for _, msg := range messages {
+		timestamp := msg.Timestamp.Format("2006-01-02 15:04:05")
+
+		// Handle different message types
+		if msg.Type == discordgo.MessageTypeDefault || msg.Type == discordgo.MessageTypeReply {
+			transcript.WriteString(fmt.Sprintf("[%s] %s: %s\n",
+				timestamp, msg.Author.GlobalName, msg.Content))
+
+			// Include attachments if any
+			if len(msg.Attachments) > 0 {
+				for _, attachment := range msg.Attachments {
+					transcript.WriteString(fmt.Sprintf("    📎 Attachment: %s (%s)\n",
+						attachment.Filename, attachment.URL))
+				}
+			}
+
+			// Include embeds if any
+			if len(msg.Embeds) > 0 {
+				transcript.WriteString(fmt.Sprintf("    📋 %d embed(s) included\n", len(msg.Embeds)))
+			}
+		} else {
+			// Handle system messages
+			transcript.WriteString(fmt.Sprintf("[%s] SYSTEM: %s\n", timestamp, getSystemMessageContent(msg)))
+		}
+
+		transcript.WriteString("\n")
+	}
+
+	return &transcript
+}
+
+// getSystemMessageContent formats system messages appropriately
+func getSystemMessageContent(msg *discordgo.Message) string {
+	switch msg.Type {
+	case discordgo.MessageTypeChannelNameChange:
+		return fmt.Sprintf("Channel name changed to: %s", msg.Content)
+	case discordgo.MessageTypeGuildMemberJoin:
+		return fmt.Sprintf("%s joined the server", msg.Author.Username)
+	case discordgo.MessageTypeUserPremiumGuildSubscription:
+		return fmt.Sprintf("%s boosted the server", msg.Author.Username)
+	case discordgo.MessageTypeChannelPinnedMessage:
+		return fmt.Sprintf("%s pinned a message", msg.Author.Username)
+	case discordgo.MessageTypeRecipientAdd:
+		return fmt.Sprintf("%s was added to the channel", msg.Author.Username)
+	case discordgo.MessageTypeRecipientRemove:
+		return fmt.Sprintf("%s was removed from the channel", msg.Author.Username)
+	case discordgo.MessageTypeCall:
+		return fmt.Sprintf("%s started a call", msg.Author.Username)
+	default:
+		return fmt.Sprintf("System message (type: %d): %s", msg.Type, msg.Content)
 	}
 }


### PR DESCRIPTION
When a support ticket channel is closed, fetches all messages, generates a formatted transcript, and sends it as an attachment to the mod action log channel. Also improves message sorting, adds message count to the embed, and handles message batching for long summaries.