### PR TITLE
Add `/intro` command to fetch user introductions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,11 @@
 # Test binary, built with `go test -c`
 *.test
 
+# Any database
+*.db
+*.sqlite
+*.sqlite3
+
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -19,3 +19,4 @@ super_admins:
 gamerpals_server_id: "your-server-id-here"
 gamerpals_mod_action_log_channel_id: "your-mod-log-channel-id-here"
 gamerpals_pairing_category_id: "your-pairing-category-id-here"
+gamerpals_introductions_forum_channel_id: "your-introductions-forum-channel-id-here"

--- a/internal/commands/handler.go
+++ b/internal/commands/handler.go
@@ -115,6 +115,21 @@ func NewSlashHandler(cfg *config.Config) *SlashHandler {
 		},
 		{
 			ApplicationCommand: &discordgo.ApplicationCommand{
+				Name:        "intro",
+				Description: "Look up a user's latest introduction post from the introductions forum",
+				Options: []*discordgo.ApplicationCommandOption{
+					{
+						Type:        discordgo.ApplicationCommandOptionUser,
+						Name:        "user",
+						Description: "The user whose introduction to look up (defaults to yourself)",
+						Required:    false,
+					},
+				},
+			},
+			HandlerFunc: h.handleIntro,
+		},
+		{
+			ApplicationCommand: &discordgo.ApplicationCommand{
 				Name:        "help",
 				Description: "Show all available commands",
 			},

--- a/internal/commands/help.go
+++ b/internal/commands/help.go
@@ -28,6 +28,11 @@ func (h *SlashHandler) handleHelp(s *discordgo.Session, i *discordgo.Interaction
 				Inline: false,
 			},
 			{
+				Name:   "/intro",
+				Value:  "Look up a user's latest introduction post\n• Use `/intro` to find your own introduction\n• Use `/intro user:@username` to find someone else's introduction",
+				Inline: false,
+			},
+			{
 				Name:   "/time",
 				Value:  "Time-related utilities\n• Use `/time parse datetime:2025-08-25 3:00 PM` to convert dates to Discord timestamps\n• Use `full:true` to see all Discord timestamp formats",
 				Inline: false,

--- a/internal/commands/intro.go
+++ b/internal/commands/intro.go
@@ -1,0 +1,124 @@
+package commands
+
+import (
+	"fmt"
+	"gamerpal/internal/utils"
+	"sort"
+
+	"github.com/bwmarrin/discordgo"
+)
+
+// handleIntro handles the intro slash command
+func (h *SlashHandler) handleIntro(s *discordgo.Session, i *discordgo.InteractionCreate) {
+	// Get the introductions forum channel ID from config
+	introsChannelID := h.config.GetGamerPalsIntroductionsForumChannelID()
+	if introsChannelID == "" {
+		s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+			Type: discordgo.InteractionResponseChannelMessageWithSource,
+			Data: &discordgo.InteractionResponseData{
+				Content: "❌ Introductions forum channel is not configured.",
+				Flags:   discordgo.MessageFlagsEphemeral,
+			},
+		})
+		return
+	}
+
+	// Get the target user (defaults to the command invoker if not specified)
+	var targetUser *discordgo.User
+	options := i.ApplicationCommandData().Options
+	if len(options) > 0 && options[0].Name == "user" {
+		targetUser = options[0].UserValue(s)
+	} else {
+		targetUser = i.Member.User
+	}
+
+	// Acknowledge the interaction immediately as this might take time
+	s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+		Type: discordgo.InteractionResponseDeferredChannelMessageWithSource,
+		Data: &discordgo.InteractionResponseData{
+			Flags: discordgo.MessageFlagsEphemeral,
+		},
+	})
+
+	// Get all active threads from the forum channel
+	threads, err := getAllActiveThreads(s, introsChannelID, i.GuildID)
+	if err != nil {
+		s.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{
+			Content: utils.StringPtr(fmt.Sprintf("❌ Error accessing introductions forum: %v", err)),
+		})
+		return
+	}
+
+	// Find threads created by the target user
+	var userThreads []*discordgo.Channel
+	for _, thread := range threads {
+		if thread.OwnerID == targetUser.ID {
+			userThreads = append(userThreads, thread)
+		}
+	}
+
+	if len(userThreads) == 0 {
+		s.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{
+			Content: utils.StringPtr(fmt.Sprintf("❌ No introduction post found for %s.", targetUser.Mention())),
+		})
+		return
+	}
+
+	// Sort threads by creation time (newest first)
+	sort.Slice(userThreads, func(i, j int) bool {
+		// Use the ID for sorting since newer Discord channels have larger IDs
+		return userThreads[i].ID > userThreads[j].ID
+	})
+
+	// Get the latest thread
+	latestThread := userThreads[0]
+
+	// Create the direct link to the forum post
+	postURL := fmt.Sprintf("https://discord.com/channels/%s/%s", i.GuildID, latestThread.ID)
+
+	// Respond with just the link as requested
+	s.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{
+		Content: utils.StringPtr(postURL),
+	})
+}
+
+// getAllActiveThreads gets all active threads from a forum channel
+func getAllActiveThreads(s *discordgo.Session, channelID string, guildID string) ([]*discordgo.Channel, error) {
+	var allThreads []*discordgo.Channel
+
+	// For forum channels, get the channel and its threads directly
+	// Note: Discord API might require different approaches depending on the version
+	// Let's try to get the channel itself first to verify it's a forum channel
+	channel, err := s.Channel(channelID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get channel: %w", err)
+	}
+
+	if channel.Type != discordgo.ChannelTypeGuildForum {
+		return nil, fmt.Errorf("channel %s is not a forum channel", channelID)
+	}
+
+	// Get active threads that are part of this forum
+	activeThreads, err := s.GuildThreadsActive(guildID)
+	if err != nil {
+		// If we can't get active threads, try a different approach
+		return nil, fmt.Errorf("failed to get active threads: %w", err)
+	}
+
+	// Filter threads that belong to our forum channel
+	for _, thread := range activeThreads.Threads {
+		if thread.ParentID == channelID {
+			allThreads = append(allThreads, thread)
+		}
+	}
+
+	// Try to get archived threads if available
+	publicArchived, err := s.ThreadsArchived(channelID, nil, 50)
+	if err == nil && publicArchived != nil {
+		for _, thread := range publicArchived.Threads {
+			allThreads = append(allThreads, thread)
+		}
+	}
+
+	return allThreads, nil
+}

--- a/internal/commands/intro.go
+++ b/internal/commands/intro.go
@@ -76,14 +76,9 @@ func (h *SlashHandler) handleIntro(s *discordgo.Session, i *discordgo.Interactio
 	// Create the direct link to the forum post
 	postURL := fmt.Sprintf("https://discord.com/channels/%s/%s", i.GuildID, latestThread.ID)
 
-	s.InteractionResponseDelete(i.Interaction)
-
 	// Respond with just the link as requested
-	s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
-		Type: discordgo.InteractionResponseChannelMessageWithSource,
-		Data: &discordgo.InteractionResponseData{
-			Content: postURL,
-		},
+	s.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{
+		Content: utils.StringPtr(postURL),
 	})
 }
 

--- a/internal/commands/intro.go
+++ b/internal/commands/intro.go
@@ -35,9 +35,6 @@ func (h *SlashHandler) handleIntro(s *discordgo.Session, i *discordgo.Interactio
 	// Acknowledge the interaction immediately as this might take time
 	s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 		Type: discordgo.InteractionResponseDeferredChannelMessageWithSource,
-		Data: &discordgo.InteractionResponseData{
-			Flags: discordgo.MessageFlagsEphemeral,
-		},
 	})
 
 	// Get all active threads from the forum channel

--- a/internal/commands/intro.go
+++ b/internal/commands/intro.go
@@ -76,9 +76,14 @@ func (h *SlashHandler) handleIntro(s *discordgo.Session, i *discordgo.Interactio
 	// Create the direct link to the forum post
 	postURL := fmt.Sprintf("https://discord.com/channels/%s/%s", i.GuildID, latestThread.ID)
 
+	s.InteractionResponseDelete(i.Interaction)
+
 	// Respond with just the link as requested
-	s.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{
-		Content: utils.StringPtr(postURL),
+	s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+		Type: discordgo.InteractionResponseChannelMessageWithSource,
+		Data: &discordgo.InteractionResponseData{
+			Content: postURL,
+		},
 	})
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -46,6 +46,10 @@ func (c *Config) GetGamerPalsPairingCategoryID() string {
 	return c.v.GetString("gamerpals_pairing_category_id")
 }
 
+func (c *Config) GetGamerPalsIntroductionsForumChannelID() string {
+	return c.v.GetString("gamerpals_introductions_forum_channel_id")
+}
+
 func (c *Config) GetSuperAdmins() []string {
 	superAdmins := c.v.GetStringSlice("super_admins")
 	if len(superAdmins) == 0 {


### PR DESCRIPTION
Introduces the /intro slash command to look up a user's latest introduction post from the introductions forum. Updates config example and config accessors to support the introductions forum channel ID, adds help documentation, and implements the command handler logic.
