### PR TITLE
Add concise response for time parse command

### DIFF
--- a/internal/commands/handler.go
+++ b/internal/commands/handler.go
@@ -224,23 +224,16 @@ func NewSlashHandler(cfg *config.Config) *SlashHandler {
 				Description: "Time-related utilities",
 				Options: []*discordgo.ApplicationCommandOption{
 					{
-						Type:        discordgo.ApplicationCommandOptionSubCommand,
-						Name:        "parse",
-						Description: "Parse a date/time and convert it to Discord timestamp format",
-						Options: []*discordgo.ApplicationCommandOption{
-							{
-								Type:        discordgo.ApplicationCommandOptionString,
-								Name:        "datetime",
-								Description: "The date/time to parse (e.g., 'January 1, 2025 MDT', '1:45PM MDT')",
-								Required:    true,
-							},
-							{
-								Type:        discordgo.ApplicationCommandOptionBoolean,
-								Name:        "full",
-								Description: "If true, print out all discord timestamp formats",
-								Required:    false,
-							},
-						},
+						Type:        discordgo.ApplicationCommandOptionString,
+						Name:        "datetime",
+						Description: "The date/time to parse (e.g., 'January 1, 2025 MDT', '1:45PM MDT')",
+						Required:    true,
+					},
+					{
+						Type:        discordgo.ApplicationCommandOptionBoolean,
+						Name:        "full",
+						Description: "If true, print out all discord timestamp formats",
+						Required:    false,
 					},
 				},
 			},

--- a/internal/commands/help.go
+++ b/internal/commands/help.go
@@ -34,7 +34,7 @@ func (h *SlashHandler) handleHelp(s *discordgo.Session, i *discordgo.Interaction
 			},
 			{
 				Name:   "/time",
-				Value:  "Time-related utilities\n• Use `/time parse datetime:2025-08-25 3:00 PM` to convert dates to Discord timestamps\n• Use `full:true` to see all Discord timestamp formats",
+				Value:  "Time-related utilities\n• Use `/time datetime:2025-08-25 3:00 PM` to convert dates to Discord timestamps\n• Use `full:true` to see all Discord timestamp formats",
 				Inline: false,
 			},
 			{

--- a/internal/commands/time.go
+++ b/internal/commands/time.go
@@ -8,50 +8,18 @@ import (
 	"github.com/bwmarrin/discordgo"
 )
 
-// handleTime handles the time slash command with subcommands
+// handleTime handles the /time command
 func (h *SlashHandler) handleTime(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	// Acknowledge the interaction immediately
 	s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 		Type: discordgo.InteractionResponseDeferredChannelMessageWithSource,
 	})
 
-	// Get the subcommand
-	options := i.ApplicationCommandData().Options
-	if len(options) == 0 {
-		embed := &discordgo.MessageEmbed{
-			Title:       "❌ Error",
-			Description: "Please specify a subcommand. Use `/time parse` to parse a date.",
-			Color:       utils.Colors.Error(),
-			Footer: &discordgo.MessageEmbedFooter{
-				Text: "GamerPal Bot",
-			},
-		}
-		s.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{
-			Embeds: &[]*discordgo.MessageEmbed{embed},
-		})
-		return
-	}
-
-	subcommand := options[0]
-	switch subcommand.Name {
-	case "parse":
-		h.handleTimeParse(s, i, subcommand.Options)
-	default:
-		embed := &discordgo.MessageEmbed{
-			Title:       "❌ Unknown Command",
-			Description: "Unknown subcommand. Use `/time parse` to parse a date.",
-			Color:       utils.Colors.Error(),
-			Footer: &discordgo.MessageEmbedFooter{
-				Text: "GamerPal Bot",
-			},
-		}
-		s.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{
-			Embeds: &[]*discordgo.MessageEmbed{embed},
-		})
-	}
+	// Forward top-level options directly to the parser
+	h.handleTimeParse(s, i, i.ApplicationCommandData().Options)
 }
 
-// handleTimeParse handles the time parse subcommand
+// handleTimeParse handles the time parse logic
 func (h *SlashHandler) handleTimeParse(s *discordgo.Session, i *discordgo.InteractionCreate, options []*discordgo.ApplicationCommandInteractionDataOption) {
 	if len(options) == 0 {
 		embed := &discordgo.MessageEmbed{


### PR DESCRIPTION
This pull request refactors the `/time` command to simplify its usage by removing the `parse` subcommand, making date parsing available directly via `/time`. The help text and command handler logic have been updated accordingly, and the output for non-full responses has been streamlined.