### PR TITLE
LFG is now a feed

### DIFF
--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -112,10 +112,6 @@ func (b *Bot) Start() error {
 		return nil
 	})
 
-	b.scheduler.RegisterNewMinuteFunc(func() error {
-		return b.slashCommandHandler.RefreshLFGNowPanel(b.session)
-	})
-
 	b.scheduler.RegisterNewHourFunc(func() error {
 		return b.config.RotateAndPruneLogs()
 	})

--- a/internal/commands/handler.go
+++ b/internal/commands/handler.go
@@ -3,7 +3,6 @@ package commands
 import (
 	"gamerpal/internal/config"
 	"gamerpal/internal/database"
-	"gamerpal/internal/lfgpanel"
 	"gamerpal/internal/pairing"
 
 	"github.com/Henry-Sarabia/igdb/v2"
@@ -25,8 +24,7 @@ type SlashCommandHandler struct {
 	DB             *database.DB
 	PairingService *pairing.PairingService
 
-	// LFG Now panel service (extracted state)
-	lfgNowSvc *lfgpanel.InMemoryService
+	// (legacy) lfg panel service removed – feed model requires only config key
 }
 
 // NewSlashCommandHandler creates a new command handler
@@ -41,18 +39,11 @@ func NewSlashCommandHandler(cfg *config.Config) *SlashCommandHandler {
 		// Continue without database for now
 	}
 
-	// initialize lfg now panel service
-	lfgSvc := lfgpanel.NewLFGPanelService(cfg).WithLogger(
-		func(msg string, args ...any) { cfg.Logger.Infof(msg, args...) },
-		func(msg string, args ...any) { cfg.Logger.Warnf(msg, args...) },
-	)
-
 	h := &SlashCommandHandler{
 		igdbClient: igdbClient,
 		Commands:   make(map[string]*Command),
 		config:     cfg,
 		DB:         db,
-		lfgNowSvc:  lfgSvc,
 	}
 
 	var adminPerms int64 = discordgo.PermissionAdministrator

--- a/internal/commands/handler.go
+++ b/internal/commands/handler.go
@@ -77,16 +77,6 @@ func NewSlashCommandHandler(cfg *config.Config) *SlashCommandHandler {
 								},
 							},
 							{
-								Type:        discordgo.ApplicationCommandOptionChannel,
-								Name:        "voice_channel",
-								Description: "Optional voice channel to join",
-								Required:    false,
-								ChannelTypes: []discordgo.ChannelType{
-									discordgo.ChannelTypeGuildVoice,
-									discordgo.ChannelTypeGuildStageVoice,
-								},
-							},
-							{
 								Type:        discordgo.ApplicationCommandOptionString,
 								Name:        "message",
 								Description: "Short message",
@@ -99,6 +89,16 @@ func NewSlashCommandHandler(cfg *config.Config) *SlashCommandHandler {
 								Required:    true,
 								MinValue:    &[]float64{1}[0],
 								MaxValue:    99,
+							},
+							{
+								Type:        discordgo.ApplicationCommandOptionChannel,
+								Name:        "voice_channel",
+								Description: "Optional voice channel to join",
+								Required:    false,
+								ChannelTypes: []discordgo.ChannelType{
+									discordgo.ChannelTypeGuildVoice,
+									discordgo.ChannelTypeGuildStageVoice,
+								},
 							},
 						},
 					},

--- a/internal/commands/handler.go
+++ b/internal/commands/handler.go
@@ -77,6 +77,16 @@ func NewSlashCommandHandler(cfg *config.Config) *SlashCommandHandler {
 								},
 							},
 							{
+								Type:        discordgo.ApplicationCommandOptionChannel,
+								Name:        "voice_channel",
+								Description: "Optional voice channel to join",
+								Required:    false,
+								ChannelTypes: []discordgo.ChannelType{
+									discordgo.ChannelTypeGuildVoice,
+									discordgo.ChannelTypeGuildStageVoice,
+								},
+							},
+							{
 								Type:        discordgo.ApplicationCommandOptionString,
 								Name:        "message",
 								Description: "Short message",

--- a/internal/commands/lfg.go
+++ b/internal/commands/lfg.go
@@ -133,7 +133,8 @@ func (h *SlashCommandHandler) handleLFGRefreshCache(s *discordgo.Session, i *dis
 	_, _ = s.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{Content: &msg})
 
 	// log to log channel
-	if err = utils.LogToChannel(h.config, s, msg+"Performed by "+i.Member.User.Mention()); err != nil {
+	logMsg := fmt.Sprintf("%s Refreshed LFG cache. Cached %d threads (active=%d, archived=%d).", i.Member.User.Mention(), cached, active, archived)
+	if err = utils.LogToChannel(h.config, s, logMsg); err != nil {
 		h.config.Logger.Warnf("Failed to log LFG cache refresh: %v", err)
 	}
 }

--- a/internal/commands/lfg.go
+++ b/internal/commands/lfg.go
@@ -103,7 +103,15 @@ func (h *SlashCommandHandler) handleLFG(s *discordgo.Session, i *discordgo.Inter
 func (h *SlashCommandHandler) handleLFGRefreshCache(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	forumID := h.config.GetGamerPalsLFGForumChannelID()
 	if forumID == "" {
-		_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{Type: discordgo.InteractionResponseChannelMessageWithSource, Data: &discordgo.InteractionResponseData{Content: "❌ LFG forum channel ID not configured.", Flags: discordgo.MessageFlagsEphemeral}})
+		_ = s.InteractionRespond(i.Interaction,
+			&discordgo.InteractionResponse{
+				Type: discordgo.InteractionResponseChannelMessageWithSource,
+				Data: &discordgo.InteractionResponseData{
+					Content: "❌ LFG forum channel ID not configured.",
+					Flags:   discordgo.MessageFlagsEphemeral,
+				},
+			},
+		)
 		return
 	}
 
@@ -113,12 +121,21 @@ func (h *SlashCommandHandler) handleLFGRefreshCache(s *discordgo.Session, i *dis
 	cached, active, archived, err := rebuildLFGThreadCache(s, h.config.GetGamerPalsServerID(), forumID)
 	if err != nil {
 		h.config.Logger.Warnf("LFG cache refresh: %v", err)
-		_, _ = s.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{Content: fmtPtr("❌ Failed to refresh cache: " + err.Error())})
+		_, _ = s.InteractionResponseEdit(i.Interaction,
+			&discordgo.WebhookEdit{
+				Content: fmtPtr("❌ Failed to refresh cache: " + err.Error()),
+			},
+		)
 		return
 	}
 
 	msg := fmt.Sprintf("✅ Refreshed LFG cache. Cached %d threads (active=%d, archived=%d).", cached, active, archived)
 	_, _ = s.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{Content: &msg})
+
+	// log to log channel
+	if err = utils.LogToChannel(h.config, s, msg+"Performed by "+i.Member.User.Mention()); err != nil {
+		h.config.Logger.Warnf("Failed to log LFG cache refresh: %v", err)
+	}
 }
 
 // rebuildLFGThreadCache lists active + archived threads for the given forum and seeds the cache.

--- a/internal/commands/lfg_now.go
+++ b/internal/commands/lfg_now.go
@@ -4,13 +4,14 @@ import (
 	"fmt"
 	"gamerpal/internal/utils"
 	"strings"
+	"time"
 
 	"github.com/bwmarrin/discordgo"
 )
 
 // handleLFGNow handles /lfg now subcommand
 func (h *SlashCommandHandler) handleLFGNow(s *discordgo.Session, i *discordgo.InteractionCreate) {
-	// Defer reply
+	// Defer an ephemeral reply
 	_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{Type: discordgo.InteractionResponseDeferredChannelMessageWithSource, Data: &discordgo.InteractionResponseData{Flags: discordgo.MessageFlagsEphemeral}})
 
 	forumID := h.config.GetGamerPalsLFGForumChannelID()
@@ -18,17 +19,15 @@ func (h *SlashCommandHandler) handleLFGNow(s *discordgo.Session, i *discordgo.In
 		_, _ = s.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{Content: utils.StringPtr("❌ LFG forum channel ID not configured.")})
 		return
 	}
-
-	// Must be invoked inside a thread whose parent is the LFG forum
+	// Must be invoked in a thread whose parent is the LFG forum
 	ch, err := s.Channel(i.ChannelID)
 	if err != nil || ch == nil || ch.ParentID != forumID {
 		_, _ = s.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{Content: utils.StringPtr("❌ This command must be used inside an LFG thread.")})
 		return
 	}
 
-	opts := i.ApplicationCommandData().Options[0].Options // subcommand options
-	var region string
-	var message string
+	opts := i.ApplicationCommandData().Options[0].Options
+	var region, message string
 	var playerCount int
 	for _, o := range opts {
 		switch o.Name {
@@ -40,7 +39,6 @@ func (h *SlashCommandHandler) handleLFGNow(s *discordgo.Session, i *discordgo.In
 			playerCount = int(o.IntValue())
 		}
 	}
-
 	message = strings.TrimSpace(message)
 	if message == "" {
 		_, _ = s.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{Content: utils.StringPtr("❌ message required")})
@@ -49,45 +47,48 @@ func (h *SlashCommandHandler) handleLFGNow(s *discordgo.Session, i *discordgo.In
 	if len(message) > 140 {
 		message = message[:137] + "..."
 	}
+	if playerCount <= 0 || playerCount > 99 {
+		_, _ = s.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{Content: utils.StringPtr("❌ invalid player_count")})
+		return
+	}
 
 	userID := i.Member.User.ID
-	_ = h.lfgNowSvc.Upsert(ch.ID, userID, region, message, playerCount)
-	if err := h.lfgNowSvc.RefreshPanel(s, h.config.GetLFGNowTTLDuration()); err != nil {
-		_, _ = s.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{Content: utils.StringPtr("✅ Added entry, but failed to refresh panel.")})
-		// Even if panel refresh fails, still attempt to post the public message below.
-		return
-	}
 
+	// Public thread announcement with @here
 	publicContent := fmt.Sprintf("@here: <@%s> is looking to play!\n\n_%s_", userID, message)
 	if _, err := s.ChannelMessageSend(ch.ID, publicContent); err != nil {
-		// Fall back to including the announcement in the ephemeral reply if sending fails
-		fallback := fmt.Sprintf("✅ Added to Looking NOW panel, but couldn't send public message for some reason.\n\n%s", publicContent)
+		fallback := fmt.Sprintf("✅ Posted, but couldn't send public thread message.\n\n%s", publicContent)
 		_, _ = s.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{Content: utils.StringPtr(fallback)})
-		return
+	} else {
+		_, _ = s.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{Content: utils.StringPtr("✅ Posted to Looking NOW feed.")})
 	}
 
-	_, _ = s.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{Content: utils.StringPtr("✅ Added to Looking NOW panel.")})
+	// Feed channel embed
+	feedChannelID := h.config.GetLFGNowPanelChannelID()
+	if feedChannelID == "" { // silently skip if not set
+		return
+	}
+	playersWord := "pals"
+	if playerCount == 1 {
+		playersWord = "pal"
+	}
+	embed := &discordgo.MessageEmbed{
+		Title:       "Looking NOW",
+		Description: fmt.Sprintf("<@%s> is looking to play in <#%s>!", userID, ch.ID),
+		Fields: []*discordgo.MessageEmbedField{
+			{Name: "Region", Value: region, Inline: true},
+			{Name: "Looking For", Value: fmt.Sprintf("%d %s", playerCount, playersWord), Inline: true},
+			{Name: "Message", Value: message, Inline: false},
+		},
+		Timestamp: time.Now().Format(time.RFC3339),
+		Footer:    &discordgo.MessageEmbedFooter{Text: "Run /lfg now again to post another update"},
+	}
+	_, _ = s.ChannelMessageSendEmbeds(feedChannelID, []*discordgo.MessageEmbed{embed})
 }
 
-// refreshLFGNowPanel rebuilds and edits/reposts the panel.
-func (h *SlashCommandHandler) refreshLFGNowPanel(s *discordgo.Session) error {
-	return h.lfgNowSvc.RefreshPanel(s, h.config.GetLFGNowTTLDuration())
-}
-
-// RefreshLFGNowPanel is an exported wrapper for background tasks.
-func (h *SlashCommandHandler) RefreshLFGNowPanel(s *discordgo.Session) error {
-	return h.refreshLFGNowPanel(s)
-}
-
-// handleLFGSetupLookingNow sets up the panel in the current channel
+// handleLFGSetupLookingNow sets the feed channel
 func (h *SlashCommandHandler) handleLFGSetupLookingNow(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{Type: discordgo.InteractionResponseDeferredChannelMessageWithSource})
-	chID := i.ChannelID
-	// Clean out any previous panel messages (best effort)
-	h.lfgNowSvc.SetupPanel(chID)
-	h.config.Set("gamerpals_lfg_now_panel_channel_id", chID)
-
-	h.lfgNowSvc.SetupPanel(chID)
-	_ = h.refreshLFGNowPanel(s) // will create empty (no messages yet)
-	_, _ = s.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{Content: utils.StringPtr("✅ Looking NOW panel initialized. It will populate as users use /lfg now in threads.")})
+	h.config.Set("gamerpals_lfg_now_panel_channel_id", i.ChannelID)
+	_, _ = s.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{Content: utils.StringPtr("✅ Looking NOW feed channel set. New /lfg now posts will appear here.")})
 }

--- a/internal/commands/lfg_now.go
+++ b/internal/commands/lfg_now.go
@@ -65,7 +65,7 @@ func (h *SlashCommandHandler) handleLFGNow(s *discordgo.Session, i *discordgo.In
 			_, _ = s.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{Content: utils.StringPtr("❌ The provided voice_channel must be a voice or stage channel.")})
 			return
 		}
-		voiceChannelMention = fmt.Sprintf("Join voice: <#%s>\\n", voiceChannelID)
+		voiceChannelMention = fmt.Sprintf("Join voice: <#%s>\n", voiceChannelID)
 	}
 
 	// Public thread announcement with @here

--- a/internal/commands/lfg_now.go
+++ b/internal/commands/lfg_now.go
@@ -99,6 +99,7 @@ func (h *SlashCommandHandler) handleLFGNow(s *discordgo.Session, i *discordgo.In
 		Description: fmt.Sprintf("<@%s> is looking to play in <#%s>!", userID, ch.ID),
 		Fields:      embedFields,
 		Timestamp:   time.Now().Format(time.RFC3339),
+		Color:       utils.Colors.Fancy(),
 		Footer:      &discordgo.MessageEmbedFooter{Text: "Run /lfg now in a game thread to make a post like this!"},
 	}
 	_, _ = s.ChannelMessageSendEmbeds(feedChannelID, []*discordgo.MessageEmbed{embed})

--- a/internal/commands/lfg_now.go
+++ b/internal/commands/lfg_now.go
@@ -81,7 +81,7 @@ func (h *SlashCommandHandler) handleLFGNow(s *discordgo.Session, i *discordgo.In
 			{Name: "Message", Value: message, Inline: false},
 		},
 		Timestamp: time.Now().Format(time.RFC3339),
-		Footer:    &discordgo.MessageEmbedFooter{Text: "Run /lfg now again to post another update"},
+		Footer:    &discordgo.MessageEmbedFooter{Text: "Run /lfg now in a game thread to make a post like this!"},
 	}
 	_, _ = s.ChannelMessageSendEmbeds(feedChannelID, []*discordgo.MessageEmbed{embed})
 }

--- a/internal/config/config_accessors.go
+++ b/internal/config/config_accessors.go
@@ -55,15 +55,6 @@ func (c *Config) GetLFGNowPanelChannelID() string {
 	return c.v.GetString("gamerpals_lfg_now_panel_channel_id")
 }
 
-// LFG "looking now" TTL (default 1h if not set or zero)
-func (c *Config) GetLFGNowTTLDuration() time.Duration {
-	d := c.v.GetDuration("gamerpals_lfg_now_ttl")
-	if d <= 0 {
-		return time.Hour
-	}
-	return d
-}
-
 // New Pals systems
 // -----
 func (c *Config) GetNewPalsSystemEnabled() bool {


### PR DESCRIPTION
This pull request removes the legacy "Looking NOW" panel service and refactors the `/lfg now` command to use a simpler, stateless feed model. The new implementation posts ephemeral responses, public thread messages, and rich embeds to a designated feed channel, and introduces support for specifying a voice channel in the command. Several background tasks and dependencies related to the old panel service are removed, and the command registration logic is improved for faster updates.
