### PR TITLE
Updated error message of lfg now when not run in a game forum

### DIFF
--- a/internal/commands/modules/lfg/now.go
+++ b/internal/commands/modules/lfg/now.go
@@ -23,7 +23,7 @@ func (m *LfgModule) handleLFGNow(s *discordgo.Session, i *discordgo.InteractionC
 	ch, err := s.Channel(i.ChannelID)
 	if err != nil || ch == nil || ch.ParentID != forumID {
 		forumChannelID := m.config.GetGamerPalsLFGForumChannelID()
-		_, _ = s.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{Content: utils.StringPtr(fmt.Sprintf("❌ This command must be used inside the desired games forum in <#%s>.", forumChannelID))})
+		_, _ = s.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{Content: utils.StringPtr(fmt.Sprintf("❌ This command must be used inside a thread in the game forum <#%s>.", forumChannelID))})
 		return
 	}
 


### PR DESCRIPTION
The output of `/lfg now` should now mention the game forum when it is not run there.