### PR TITLE
Add event feed forwarding for new scheduled events

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -23,6 +23,10 @@ gamerpals_pairing_category_id: "your-pairing-category-id-here"
 gamerpals_introductions_forum_channel_id: "your-introductions-forum-channel-id-here"
 gamerpals_lfg_forum_channel_id: "your-lfg-forum-channel-id-here"
 
+# Event Feed Configuration
+# When a new scheduled event is created, it is forwarded to this channel
+event_feed_channel_id: "your-event-feed-channel-id-here"
+
 # Introduction Feed Configuration
 # When a new intro is posted, it can be forwarded to a dedicated channel
 intro_feed_channel_id: "your-intro-feed-channel-id-here"

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -47,7 +47,7 @@ func New(cfg *config.Config) (*Bot, error) {
 	// mark not ready yet (zero value false, explicit for clarity)
 	bot.ready.Store(false)
 
-	// Set intents - we need guild, member, message, message content, direct message intents
+	// Set intents - we need guild, member, message, message content, direct message, message reaction, and guild scheduled event intents
 	session.Identify.Intents = discordgo.IntentsGuilds | discordgo.IntentsGuildMembers | discordgo.IntentsGuildMessages | discordgo.IntentMessageContent | discordgo.IntentDirectMessages | discordgo.IntentsGuildMessageReactions | discordgo.IntentsGuildScheduledEvents
 
 	// Add event handlers

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -48,7 +48,7 @@ func New(cfg *config.Config) (*Bot, error) {
 	bot.ready.Store(false)
 
 	// Set intents - we need guild, member, message, message content, direct message intents
-	session.Identify.Intents = discordgo.IntentsGuilds | discordgo.IntentsGuildMembers | discordgo.IntentsGuildMessages | discordgo.IntentMessageContent | discordgo.IntentDirectMessages | discordgo.IntentsGuildMessageReactions
+	session.Identify.Intents = discordgo.IntentsGuilds | discordgo.IntentsGuildMembers | discordgo.IntentsGuildMessages | discordgo.IntentMessageContent | discordgo.IntentDirectMessages | discordgo.IntentsGuildMessageReactions | discordgo.IntentsGuildScheduledEvents
 
 	// Add event handlers
 	session.AddHandler(bot.onReady)
@@ -69,6 +69,9 @@ func New(cfg *config.Config) (*Bot, error) {
 	})
 	session.AddHandler(func(s *discordgo.Session, r *discordgo.GuildMemberAdd) {
 		events.OnGuildMemberAdd(s, r, cfg)
+	})
+	session.AddHandler(func(s *discordgo.Session, e *discordgo.GuildScheduledEventCreate) {
+		events.OnGuildScheduledEventCreate(s, e, cfg)
 	})
 
 	// Forum thread lifecycle events wired into cache service and intro feed

--- a/internal/commands/modules/config/config.go
+++ b/internal/commands/modules/config/config.go
@@ -164,6 +164,7 @@ func (m *ConfigModule) handleConfigListKeys(s *discordgo.Session, i *discordgo.I
 		{"gamerpals_voice_sync_category_id", true},         // Harmless ID
 		{"intro_feed_channel_id", true},                    // Harmless ID
 		{"intro_feed_rate_limit_hours", true},              // Duration setting
+		{"event_feed_channel_id", true},                    // Harmless ID
 		{"new_pals_system_enabled", true},                  // Boolean setting
 		{"new_pals_role_id", true},                         // Harmless ID
 		{"new_pals_channel_id", true},                      // Harmless ID

--- a/internal/config/config_accessors.go
+++ b/internal/config/config_accessors.go
@@ -122,6 +122,14 @@ func (c *Config) GetString(key string) string {
 	return c.v.GetString(key)
 }
 
+// Event Feed configuration
+// -----
+
+// GetEventFeedChannelID returns the channel ID where new scheduled events are forwarded
+func (c *Config) GetEventFeedChannelID() string {
+	return c.v.GetString("event_feed_channel_id")
+}
+
 // Introduction Feed configuration
 // -----
 

--- a/internal/events/guild_scheduled_event_create.go
+++ b/internal/events/guild_scheduled_event_create.go
@@ -18,10 +18,8 @@ func OnGuildScheduledEventCreate(s *discordgo.Session, e *discordgo.GuildSchedul
 	eventURL := fmt.Sprintf("https://discord.com/events/%s/%s", e.GuildID, e.ID)
 
 	msg := heredoc.Docf(`
-		New event created! [Link](<%s>)
-
-		Title: %s
-	`, eventURL, e.Name)
+		New event created! [Click here to view details](%s)
+	`, eventURL)
 
 	if _, err := s.ChannelMessageSend(feedChannelID, msg); err != nil {
 		cfg.Logger.Errorf("Failed to send event feed message: %v", err)

--- a/internal/events/guild_scheduled_event_create.go
+++ b/internal/events/guild_scheduled_event_create.go
@@ -1,0 +1,29 @@
+package events
+
+import (
+	"fmt"
+	"gamerpal/internal/config"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/bwmarrin/discordgo"
+)
+
+// OnGuildScheduledEventCreate forwards new scheduled events to the configured event feed channel.
+func OnGuildScheduledEventCreate(s *discordgo.Session, e *discordgo.GuildScheduledEventCreate, cfg *config.Config) {
+	feedChannelID := cfg.GetEventFeedChannelID()
+	if feedChannelID == "" {
+		return
+	}
+
+	eventURL := fmt.Sprintf("https://discord.com/events/%s/%s", e.GuildID, e.ID)
+
+	msg := heredoc.Docf(`
+		New event created! [Link](<%s>)
+
+		Title: %s
+	`, eventURL, e.Name)
+
+	if _, err := s.ChannelMessageSend(feedChannelID, msg); err != nil {
+		cfg.Logger.Errorf("Failed to send event feed message: %v", err)
+	}
+}

--- a/internal/events/guild_scheduled_event_create.go
+++ b/internal/events/guild_scheduled_event_create.go
@@ -15,6 +15,11 @@ func OnGuildScheduledEventCreate(s *discordgo.Session, e *discordgo.GuildSchedul
 		return
 	}
 
+	gamerPalsServerID := cfg.GetGamerPalsServerID()
+	if gamerPalsServerID != "" && e.GuildID != gamerPalsServerID {
+		return
+	}
+
 	eventURL := fmt.Sprintf("https://discord.com/events/%s/%s", e.GuildID, e.ID)
 
 	msg := heredoc.Docf(`


### PR DESCRIPTION
When a Discord scheduled event is created, a notification is sent to the channel configured via `event_feed_channel_id`.

**Format:**
```
New event created! [Link](<URL>)

Title: <title>
```

**Changes:**
- Add `event_feed_channel_id` config key and accessor
- Add `GuildScheduledEventCreate` handler in `internal/events`
- Wire handler and `GuildScheduledEvents` intent in `bot.go`
- Add `event_feed_channel_id` to `/config list-keys` and `/config set`
- Update `config.example.yaml` with new setting