### PR TITLE
feat: generic multi-language translate command

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -33,6 +33,12 @@ intro_feed_channel_id: "your-intro-feed-channel-id-here"
 # Hours between allowed feed posts per user (prevents spam from delete+repost)
 intro_feed_rate_limit_hours: 48
 
+# Translate Command Configuration
+# Controls which language style the "Translate" context menu command uses.
+# Options: "caveman", "gen_alpha", "old_man", "80s", "high_society", "random"
+# "random" will pick a random language each time.
+translate_language: "random"
+
 # Voice Channel Permission Sync
 # When @everyone Connect is denied on voice channels in this category,
 # also deny View Channel (and vice versa for allowing)

--- a/internal/commands/modules/config/config.go
+++ b/internal/commands/modules/config/config.go
@@ -172,6 +172,7 @@ func (m *ConfigModule) handleConfigListKeys(s *discordgo.Session, i *discordgo.I
 		{"new_pals_time_between_welcome_messages", true},   // Duration setting
 		{"database_path", true},                            // File path
 		{"log_dir", true},                                  // Directory path
+		{"translate_language", true},                        // Translate style
 	}
 
 	// Format the keys into a readable list

--- a/internal/commands/modules/fun/fun.go
+++ b/internal/commands/modules/fun/fun.go
@@ -78,6 +78,17 @@ var translateLanguages = map[string]translateLanguage{
 			ONLY reply with the translated text, nothing else.
 		`),
 	},
+	"canadian": {
+		Name: "Canadian",
+		SystemPrompt: heredoc.Doc(`
+			Translate the user's message to stereotypical Canadian English.
+			Use phrases like "eh", "sorry", "aboot", "bud", "toque", "double-double", "give'r", "hoser", "beauty", "out for a rip", "take off", "you betcha", etc.
+			Be overly polite, apologetic, and reference hockey, Tim Hortons, and the cold when possible.
+			Keep roughly the same word length.
+			Do not use em-dashes.
+			ONLY reply with the translated text, nothing else.
+		`),
+	},
 }
 
 // translateLanguageKeys returns a stable list of language keys for random selection

--- a/internal/commands/modules/fun/fun.go
+++ b/internal/commands/modules/fun/fun.go
@@ -5,21 +5,86 @@ import (
 	"gamerpal/internal/commands/types"
 	"gamerpal/internal/config"
 	"gamerpal/internal/utils"
+	"math/rand"
+	"strings"
 	"time"
 
+	"github.com/MakeNowJust/heredoc"
 	"github.com/bwmarrin/discordgo"
 )
 
-const cavemanSystemPrompt = `translate to broken caveman english in roughly the same word length.
+type translateLanguage struct {
+	Name         string
+	SystemPrompt string
+}
 
-ONLY reply with the translation in this format:
+var translateLanguages = map[string]translateLanguage{
+	"caveman": {
+		Name: "Caveman",
+		SystemPrompt: heredoc.Doc(`
+			Translate the user's message to broken caveman english in roughly the same word length.
+			ONLY reply with the translated text, nothing else.
+		`),
+	},
+	"gen_alpha": {
+		Name: "Gen Alpha",
+		SystemPrompt: heredoc.Doc(`
+			Translate the user's message to gen alpha slang (skibidi, rizz, no cap, bussin, slay, fr fr, sus, brainrot, etc.) in roughly the same word length.
+			ONLY reply with the translated text, nothing else.
+		`),
+	},
+	"old_man": {
+		Name: "Old Man",
+		SystemPrompt: heredoc.Doc(`
+			Translate the user's message to grumpy old man talk.
+			Use phrases like "back in my day", "what? speak up!", "you kids these days", "in my time we...", "I tell ya", etc.
+			Keep roughly the same word length.
+			ONLY reply with the translated text, nothing else.
+		`),
+	},
+	"80s": {
+		Name: "80's",
+		SystemPrompt: heredoc.Doc(`
+			Translate the user's message to 1980s slang.
+			Use phrases like "totally tubular", "gnarly", "radical", "gag me with a spoon", "like, totally", "bodacious", "righteous", "bogus", "grody", etc.
+			Keep roughly the same word length.
+			ONLY reply with the translated text, nothing else.
+		`),
+	},
+	"high_society": {
+		Name: "High Society",
+		SystemPrompt: heredoc.Doc(`
+			Translate the user's message to fancy high society English.
+			Use eloquent, sophisticated vocabulary, formal phrasing, and an air of aristocratic refinement.
+			Think Victorian upper class, "indeed", "most assuredly", "I dare say", "one finds", "indubitably", etc.
+			Keep roughly the same word length.
+			ONLY reply with the translated text, nothing else.
+		`),
+	},
+}
 
-<format>
+// translateLanguageKeys returns a stable list of language keys for random selection
+var translateLanguageKeys = func() []string {
+	keys := make([]string, 0, len(translateLanguages))
+	for k := range translateLanguages {
+		keys = append(keys, k)
+	}
+	return keys
+}()
 
-hey, I translated this to caveman for you:
-
-> <translation>
-</format>`
+// getTranslateLanguage returns the configured translate language, resolving "random" to a random pick.
+func (m *FunModule) getTranslateLanguage() translateLanguage {
+	key := m.config.GetTranslateLanguage()
+	if key == "random" {
+		key = translateLanguageKeys[rand.Intn(len(translateLanguageKeys))]
+	}
+	lang, ok := translateLanguages[key]
+	if !ok {
+		// Fall back to caveman if the config value is invalid
+		return translateLanguages["caveman"]
+	}
+	return lang
+}
 
 // FunModule implements the CommandModule interface for fun commands
 type FunModule struct {
@@ -70,13 +135,13 @@ func (m *FunModule) Register(cmds map[string]*types.Command, deps *types.Depende
 		HandlerFunc: m.handleTyping,
 	}
 
-	cmds["Translate to caveman"] = &types.Command{
+	cmds["Translate"] = &types.Command{
 		ApplicationCommand: &discordgo.ApplicationCommand{
-			Name:                     "Translate to caveman",
+			Name:                     "Translate",
 			Type:                     discordgo.MessageApplicationCommand,
 			DefaultMemberPermissions: &modPerms,
 		},
-		HandlerFunc: m.handleCavemanTranslate,
+		HandlerFunc: m.handleTranslate,
 	}
 
 	cmds["connect4"] = &types.Command{
@@ -97,8 +162,8 @@ func (m *FunModule) Register(cmds map[string]*types.Command, deps *types.Depende
 	}
 }
 
-// handleCavemanTranslate handles the "Translate to caveman" message context menu command.
-func (m *FunModule) handleCavemanTranslate(s *discordgo.Session, i *discordgo.InteractionCreate) {
+// handleTranslate handles the "Translate" message context menu command.
+func (m *FunModule) handleTranslate(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	data := i.ApplicationCommandData()
 	targetMsg := data.Resolved.Messages[data.TargetID]
 
@@ -113,6 +178,8 @@ func (m *FunModule) handleCavemanTranslate(s *discordgo.Session, i *discordgo.In
 		return
 	}
 
+	lang := m.getTranslateLanguage()
+
 	// Defer so the user knows we're working on it
 	_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 		Type: discordgo.InteractionResponseDeferredChannelMessageWithSource,
@@ -122,7 +189,7 @@ func (m *FunModule) handleCavemanTranslate(s *discordgo.Session, i *discordgo.In
 	})
 
 	modelsClient := utils.NewModelsClient(m.config)
-	translation := modelsClient.ModelsRequest(cavemanSystemPrompt, targetMsg.Content, "deepseek/DeepSeek-V3-0324")
+	translation := modelsClient.ModelsRequest(lang.SystemPrompt, targetMsg.Content, "deepseek/DeepSeek-V3-0324")
 
 	if translation == "" {
 		_, _ = s.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{
@@ -131,9 +198,13 @@ func (m *FunModule) handleCavemanTranslate(s *discordgo.Session, i *discordgo.In
 		return
 	}
 
+	// Format the raw translation into a quote block
+	quoted := "> " + strings.ReplaceAll(strings.TrimSpace(translation), "\n", "\n> ")
+	message := fmt.Sprintf("Hey, I translated this to %s for you:\n\n%s", lang.Name, quoted)
+
 	// Reply to the original message in the channel
 	_, err := s.ChannelMessageSendComplex(i.ChannelID, &discordgo.MessageSend{
-		Content: translation,
+		Content: message,
 		Reference: &discordgo.MessageReference{
 			MessageID: targetMsg.ID,
 			ChannelID: i.ChannelID,
@@ -147,7 +218,7 @@ func (m *FunModule) handleCavemanTranslate(s *discordgo.Session, i *discordgo.In
 	}
 
 	_, _ = s.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{
-		Content: strPtr("🪨 Caveman translation sent!"),
+		Content: strPtr(fmt.Sprintf("✅ %s translation sent!", lang.Name)),
 	})
 }
 

--- a/internal/commands/modules/fun/fun.go
+++ b/internal/commands/modules/fun/fun.go
@@ -23,13 +23,15 @@ var translateLanguages = map[string]translateLanguage{
 		Name: "Caveman",
 		SystemPrompt: heredoc.Doc(`
 			Translate the user's message to broken caveman english in roughly the same word length.
+			Do not use em-dashes.
 			ONLY reply with the translated text, nothing else.
 		`),
 	},
 	"gen_alpha": {
 		Name: "Gen Alpha",
 		SystemPrompt: heredoc.Doc(`
-			Translate the user's message to gen alpha slang (skibidi, rizz, no cap, bussin, slay, fr fr, sus, brainrot, etc.) in roughly the same word length.
+			Translate the user's message to gen alpha slang (skibidi, rizz, no cap, bussin, slay, fr fr, sus, brainrot, sigma, gyat, mid, delulu, aura, cooked, fanum tax, NPC, dog water, touch grass, etc.) in roughly the same word length.
+			Do not use em-dashes.
 			ONLY reply with the translated text, nothing else.
 		`),
 	},
@@ -37,8 +39,9 @@ var translateLanguages = map[string]translateLanguage{
 		Name: "Old Man",
 		SystemPrompt: heredoc.Doc(`
 			Translate the user's message to grumpy old man talk.
-			Use phrases like "back in my day", "what? speak up!", "you kids these days", "in my time we...", "I tell ya", etc.
+			Use phrases like "back in my day", "what? speak up!", "you kids these days", "when I was your age", "they don't make 'em like they used to", "turn that racket down!", "I tell ya", "the world's gone crazy", etc.
 			Keep roughly the same word length.
+			Do not use em-dashes.
 			ONLY reply with the translated text, nothing else.
 		`),
 	},
@@ -46,8 +49,9 @@ var translateLanguages = map[string]translateLanguage{
 		Name: "80's",
 		SystemPrompt: heredoc.Doc(`
 			Translate the user's message to 1980s slang.
-			Use phrases like "totally tubular", "gnarly", "radical", "gag me with a spoon", "like, totally", "bodacious", "righteous", "bogus", "grody", etc.
+			Use phrases like "totally tubular", "gnarly", "radical", "rad", "gag me with a spoon", "like, totally", "bodacious", "righteous", "bogus", "grody", "bitchin'", "fresh", "take a chill pill", "no duh", etc.
 			Keep roughly the same word length.
+			Do not use em-dashes.
 			ONLY reply with the translated text, nothing else.
 		`),
 	},
@@ -58,6 +62,7 @@ var translateLanguages = map[string]translateLanguage{
 			Use eloquent, sophisticated vocabulary, formal phrasing, and an air of aristocratic refinement.
 			Think Victorian upper class, "indeed", "most assuredly", "I dare say", "one finds", "indubitably", etc.
 			Keep roughly the same word length.
+			Do not use em-dashes.
 			ONLY reply with the translated text, nothing else.
 		`),
 	},

--- a/internal/commands/modules/fun/fun.go
+++ b/internal/commands/modules/fun/fun.go
@@ -66,6 +66,17 @@ var translateLanguages = map[string]translateLanguage{
 			ONLY reply with the translated text, nothing else.
 		`),
 	},
+	"doakes": {
+		Name: "Sergeant Doakes",
+		SystemPrompt: heredoc.Doc(`
+			Translate the user's message in the style of Sergeant Doakes from Dexter, who has just discovered that Dexter is the Bay Harbor Butcher.
+			He is intense, suspicious, confrontational, and angry. Use phrases like "surprise, motherfucker", "I'm watching you", "you think I don't see what you're doing?", "I knew it", "you're a killer", etc.
+			Everything should drip with paranoid accusation and barely-contained rage.
+			Keep roughly the same word length.
+			Do not use em-dashes.
+			ONLY reply with the translated text, nothing else.
+		`),
+	},
 }
 
 // translateLanguageKeys returns a stable list of language keys for random selection

--- a/internal/commands/modules/fun/fun.go
+++ b/internal/commands/modules/fun/fun.go
@@ -69,9 +69,10 @@ var translateLanguages = map[string]translateLanguage{
 	"doakes": {
 		Name: "Sergeant Doakes",
 		SystemPrompt: heredoc.Doc(`
-			Translate the user's message in the style of Sergeant Doakes from Dexter, who has just discovered that Dexter is the Bay Harbor Butcher.
-			He is intense, suspicious, confrontational, and angry. Use phrases like "surprise, motherfucker", "I'm watching you", "you think I don't see what you're doing?", "I knew it", "you're a killer", etc.
-			Everything should drip with paranoid accusation and barely-contained rage.
+			Translate the user's message in the style of Sergeant Doakes from Dexter.
+			He is intense, suspicious, confrontational, and always thinks something shady is going on.
+			Use phrases like "surprise, motherfucker", "stop grinning like a fucking psycho", "I knew there was something wrong with you", "stay out of my way", "you think I don't see what you're doing?", "motherfucker", etc.
+			Everything should drip with paranoid suspicion and barely-contained rage.
 			Keep roughly the same word length.
 			Do not use em-dashes.
 			ONLY reply with the translated text, nothing else.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -168,6 +168,7 @@ func setDefaults(v *viper.Viper) {
 	// Add any default values here if needed in the future
 	v.SetDefault("log_dir", "./logs")
 	v.SetDefault("database_path", "./gamerpal.db")
+	v.SetDefault("translate_language", "random")
 }
 
 // bindEnvs binds environment variables to viper keys

--- a/internal/config/config_accessors.go
+++ b/internal/config/config_accessors.go
@@ -146,3 +146,16 @@ func (c *Config) GetIntroFeedRateLimitHours() int {
 	}
 	return hours
 }
+
+// Translate language configuration
+// -----
+
+// GetTranslateLanguage returns the configured translate language style.
+// Valid values: "caveman", "gen_alpha", "old_man", "80s", "high_society", "random"
+func (c *Config) GetTranslateLanguage() string {
+	lang := c.v.GetString("translate_language")
+	if lang == "" {
+		return "random"
+	}
+	return lang
+}


### PR DESCRIPTION
Replace the **Translate to caveman** context menu command with a generic **Translate** command that supports multiple language styles:

- **Caveman** – broken caveman english
- **Gen Alpha** – skibidi, rizz, no cap, etc.
- **Old Man** – grumpy old man talk
- **80's** – totally tubular, gnarly, etc.
- **High Society** – fancy aristocratic english

The language is controlled by the `translate_language` config setting. Set to `random` (the default) to randomly pick a language each time.

The bot now requests raw translations from the LLM and formats the response into a Discord quote block itself.