### PR TITLE
feat: add 1984 audit-logging module

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -39,6 +39,11 @@ intro_feed_rate_limit_hours: 48
 # "random" will pick a random language each time.
 translate_language: "random"
 
+# 1984 Module - message activity logging
+# Channel where every message create/edit/delete and reaction add/remove is logged.
+# Leave empty to disable the module.
+gamerpals_1984_log_channel_id: ""
+
 # Voice Channel Permission Sync
 # When @everyone Connect is denied on voice channels in this category,
 # also deny View Channel (and vice versa for allowing)

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/charmbracelet/log v0.4.2
 	github.com/markusmobius/go-dateparser v1.2.4
 	github.com/mattn/go-sqlite3 v1.14.28
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/spf13/viper v1.20.1
 	github.com/stretchr/testify v1.10.0
@@ -40,7 +41,6 @@ require (
 	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.3 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/sagikazarmark/locafero v0.7.0 // indirect
 	github.com/sourcegraph/conc v0.3.0 // indirect

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -13,6 +13,7 @@ import (
 
 	"gamerpal/internal/commands"
 	"gamerpal/internal/commands/modules/intro"
+	nineteeneightyfour "gamerpal/internal/commands/modules/nineteeneightyfour"
 	"gamerpal/internal/config"
 	"gamerpal/internal/events"
 	"gamerpal/internal/scheduler"
@@ -50,6 +51,13 @@ func New(cfg *config.Config) (*Bot, error) {
 	// Set intents - we need guild, member, message, message content, direct message, message reaction, and guild scheduled event intents
 	session.Identify.Intents = discordgo.IntentsGuilds | discordgo.IntentsGuildMembers | discordgo.IntentsGuildMessages | discordgo.IntentMessageContent | discordgo.IntentDirectMessages | discordgo.IntentsGuildMessageReactions | discordgo.IntentsGuildScheduledEvents
 
+	// Enable per-channel message caching so the 1984 module can show the
+	// "before" version of edited and deleted messages. discordgo populates
+	// MessageUpdate.BeforeUpdate / MessageDelete.BeforeDelete from this cache.
+	if session.State != nil {
+		session.State.MaxMessageCount = 500
+	}
+
 	// Add event handlers
 	session.AddHandler(bot.onReady)
 
@@ -61,6 +69,20 @@ func New(cfg *config.Config) (*Bot, error) {
 	session.AddHandler(func(s *discordgo.Session, m *discordgo.MessageCreate) {
 		events.OnMessageCreate(s, m, cfg)
 	})
+
+	// 1984 module - surveillance/audit logging across all channels.
+	if mod, ok := handler.GetModule("1984").(*nineteeneightyfour.Module); ok {
+		session.AddHandler(mod.OnMessageCreate)
+		session.AddHandler(mod.OnMessageUpdate)
+		session.AddHandler(mod.OnMessageDelete)
+		session.AddHandler(mod.OnMessageReactionAdd)
+		session.AddHandler(mod.OnMessageReactionRemove)
+		session.AddHandler(mod.OnChannelCreate)
+		session.AddHandler(mod.OnChannelUpdate)
+		// Raw event handler catches gateway events that discordgo doesn't
+		// model as typed events (e.g. VOICE_CHANNEL_STATUS_UPDATE).
+		session.AddHandler(mod.OnRawEvent)
+	}
 	session.AddHandler(func(s *discordgo.Session, c *discordgo.ChannelUpdate) {
 		events.OnChannelUpdate(s, c, cfg)
 	})

--- a/internal/commands/module_handler.go
+++ b/internal/commands/module_handler.go
@@ -11,6 +11,7 @@ import (
 	"gamerpal/internal/commands/modules/intro"
 	"gamerpal/internal/commands/modules/lfg"
 	"gamerpal/internal/commands/modules/log"
+	nineteeneightyfour "gamerpal/internal/commands/modules/nineteeneightyfour"
 	"gamerpal/internal/commands/modules/ping"
 	"gamerpal/internal/commands/modules/poll"
 	"gamerpal/internal/commands/modules/prune"
@@ -103,6 +104,7 @@ func (h *ModuleHandler) registerModules() {
 		{"poll", poll.New(h.deps)},
 		{"status", status.New(h.deps)},
 		{"fun", fun.New(h.deps)},
+		{"1984", nineteeneightyfour.New(h.deps)},
 	}
 
 	for _, m := range modules {

--- a/internal/commands/modules/config/config.go
+++ b/internal/commands/modules/config/config.go
@@ -162,6 +162,7 @@ func (m *ConfigModule) handleConfigListKeys(s *discordgo.Session, i *discordgo.I
 		{"lfg_now_role_id", true},                          // Harmless ID
 		{"lfg_now_role_duration", true},                    // Duration setting
 		{"gamerpals_voice_sync_category_id", true},         // Harmless ID
+		{"gamerpals_1984_log_channel_id", true},            // Harmless ID
 		{"intro_feed_channel_id", true},                    // Harmless ID
 		{"intro_feed_rate_limit_hours", true},              // Duration setting
 		{"event_feed_channel_id", true},                    // Harmless ID
@@ -172,7 +173,7 @@ func (m *ConfigModule) handleConfigListKeys(s *discordgo.Session, i *discordgo.I
 		{"new_pals_time_between_welcome_messages", true},   // Duration setting
 		{"database_path", true},                            // File path
 		{"log_dir", true},                                  // Directory path
-		{"translate_language", true},                        // Translate style
+		{"translate_language", true},                       // Translate style
 	}
 
 	// Format the keys into a readable list

--- a/internal/commands/modules/nineteeneightyfour/nineteeneightyfour.go
+++ b/internal/commands/modules/nineteeneightyfour/nineteeneightyfour.go
@@ -9,6 +9,8 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 	"strings"
 	"time"
 	"unicode/utf8"
@@ -42,12 +44,18 @@ type Module struct {
 	// dispatchLog sends a fully-built payload to the given channel. Overridable
 	// in tests so handler logic can be exercised without hitting the network.
 	dispatchLog func(s *discordgo.Session, channelID string, p payload) error
+
+	// fetchImage downloads an image attachment URL and returns its bytes.
+	// Returns an error for non-image responses, oversized bodies, or any
+	// network failure. Overridable in tests so we never hit the network.
+	fetchImage func(url string, maxBytes int) ([]byte, error)
 }
 
 // New creates a new 1984 module instance.
 func New(deps *types.Dependencies) *Module {
 	m := &Module{config: deps.Config}
 	m.dispatchLog = m.defaultDispatchLog
+	m.fetchImage = defaultFetchImage
 	return m
 }
 
@@ -56,6 +64,9 @@ func (m *Module) Register(_ map[string]*types.Command, deps *types.Dependencies)
 	m.config = deps.Config
 	if m.dispatchLog == nil {
 		m.dispatchLog = m.defaultDispatchLog
+	}
+	if m.fetchImage == nil {
+		m.fetchImage = defaultFetchImage
 	}
 }
 
@@ -103,7 +114,12 @@ func (m *Module) OnMessageCreate(s *discordgo.Session, e *discordgo.MessageCreat
 		parts = append(parts, fmt.Sprintf("**Components:** %d", len(e.Components)))
 	}
 
-	m.send(s, strings.Join(parts, "\n"), namedFile("content.txt", body))
+	// Re-host image attachments in the log channel so evidence survives the
+	// original message being edited or deleted (its CDN URL is short-lived).
+	images, imgNotes := m.rehostImages(e.Attachments)
+	parts = append(parts, imgNotes...)
+
+	m.sendWithFiles(s, strings.Join(parts, "\n"), images, namedFile("content.txt", body))
 }
 
 // OnMessageUpdate logs message edits with a before/after view.
@@ -527,17 +543,26 @@ type payload struct {
 	files   []fileSpec
 }
 
-// buildPayload turns a rendered message body and a set of optional
-// attachments into a Discord-safe payload that:
+// buildPayload turns a rendered message body, a set of optional text
+// attachments (offered as .txt fallbacks for long inline content), and a
+// set of pre-built binary files (e.g. re-hosted images) into a Discord-safe
+// payload that:
 //   - has content <= maxMessageContentChars
 //   - has at most maxAttachmentsPerMessage attachments
 //   - has every attachment <= maxAttachmentBytes
 //
-// Long attachments are uploaded as files; if the content itself is too
-// long it is moved into a log.txt file and the content becomes a short
-// pointer message.
-func buildPayload(content string, attachments []fileAttachment) payload {
-	var files []fileSpec
+// Binary files take priority for attachment slots since their bytes can't
+// be losslessly merged into a .txt fallback. If the total file count
+// exceeds the per-message attachment cap, the excess is dropped and the
+// content gains a warning note.
+func buildPayload(content string, attachments []fileAttachment, extraFiles []fileSpec) payload {
+	files := make([]fileSpec, 0, len(extraFiles)+len(attachments)+1)
+	for _, f := range extraFiles {
+		if len(f.content) > maxAttachmentBytes {
+			f.content = clampBytes(f.content, maxAttachmentBytes)
+		}
+		files = append(files, f)
+	}
 	for _, a := range attachments {
 		if a.content == "" {
 			continue
@@ -559,23 +584,14 @@ func buildPayload(content string, attachments []fileAttachment) payload {
 	}
 
 	if len(files) > maxAttachmentsPerMessage {
-		// Merge overflow files into a single combined.txt to stay within
-		// Discord's per-message attachment cap.
-		keep := files[:maxAttachmentsPerMessage-1]
-		overflow := files[maxAttachmentsPerMessage-1:]
-		var buf bytes.Buffer
-		for _, f := range overflow {
-			buf.WriteString("=== ")
-			buf.WriteString(f.name)
-			buf.WriteString(" ===\n")
-			buf.Write(f.content)
-			buf.WriteString("\n\n")
+		dropped := len(files) - maxAttachmentsPerMessage
+		files = files[:maxAttachmentsPerMessage]
+		note := fmt.Sprintf("⚠️ %d attachment(s) omitted due to Discord per-message limit.\n", dropped)
+		content = note + content
+		if len(content) > maxMessageContentChars {
+			const ellipsis = "…"
+			content = truncateUTF8(content, maxMessageContentChars-len(ellipsis)) + ellipsis
 		}
-		merged := fileSpec{
-			name:    "combined.txt",
-			content: clampBytes(buf.Bytes(), maxAttachmentBytes),
-		}
-		files = append(keep, merged)
 	}
 
 	return payload{content: content, files: files}
@@ -615,12 +631,19 @@ func clampBytes(b []byte, max int) []byte {
 // otherwise needed because the rendered message is itself too long) are
 // uploaded as files to guarantee logging never fails for long messages.
 func (m *Module) send(s *discordgo.Session, content string, attachments ...fileAttachment) {
+	m.sendWithFiles(s, content, nil, attachments...)
+}
+
+// sendWithFiles is like send but also includes a set of pre-built binary
+// files (e.g. re-hosted image attachments). Binary files take priority
+// over text fallbacks if the per-message attachment cap is hit.
+func (m *Module) sendWithFiles(s *discordgo.Session, content string, extraFiles []fileSpec, attachments ...fileAttachment) {
 	channelID := m.config.GetGamerPals1984LogChannelID()
 	if channelID == "" {
 		return
 	}
 
-	p := buildPayload(content, attachments)
+	p := buildPayload(content, attachments, extraFiles)
 	if err := m.dispatchLog(s, channelID, p); err != nil {
 		m.config.Logger.Warnf("1984: failed to send log message: %v", err)
 	}
@@ -633,7 +656,7 @@ func (m *Module) defaultDispatchLog(s *discordgo.Session, channelID string, p pa
 	for _, f := range p.files {
 		files = append(files, &discordgo.File{
 			Name:        f.name,
-			ContentType: "text/plain",
+			ContentType: detectContentType(f.name, f.content),
 			Reader:      bytes.NewReader(f.content),
 		})
 	}
@@ -643,4 +666,89 @@ func (m *Module) defaultDispatchLog(s *discordgo.Session, channelID string, p pa
 		AllowedMentions: &discordgo.MessageAllowedMentions{}, // never ping anyone from the log
 	})
 	return err
+}
+
+// detectContentType picks a Content-Type for an upload. Anything that looks
+// like text uses text/plain; otherwise we use http.DetectContentType so
+// re-hosted images render inline in Discord.
+func detectContentType(name string, data []byte) string {
+	lower := strings.ToLower(name)
+	if strings.HasSuffix(lower, ".txt") || strings.HasSuffix(lower, ".patch") || strings.HasSuffix(lower, ".log") {
+		return "text/plain"
+	}
+	if len(data) == 0 {
+		return "application/octet-stream"
+	}
+	return http.DetectContentType(data)
+}
+
+// rehostImages downloads each image attachment and returns them as files
+// suitable for re-uploading to the log channel. Returns ancillary "notes"
+// the caller appends to the log message body (one per failed/oversized
+// download). Non-image attachments are skipped silently.
+func (m *Module) rehostImages(attachments []*discordgo.MessageAttachment) ([]fileSpec, []string) {
+	if len(attachments) == 0 || m.fetchImage == nil {
+		return nil, nil
+	}
+	var files []fileSpec
+	var notes []string
+	for _, a := range attachments {
+		if a == nil || !isImageAttachment(a) {
+			continue
+		}
+		if a.Size > maxAttachmentBytes {
+			notes = append(notes, fmt.Sprintf("⚠️ Image `%s` not re-hosted (%d bytes exceeds %d-byte cap).", a.Filename, a.Size, maxAttachmentBytes))
+			continue
+		}
+		data, err := m.fetchImage(a.URL, maxAttachmentBytes)
+		if err != nil {
+			notes = append(notes, fmt.Sprintf("⚠️ Image `%s` not re-hosted: %v.", a.Filename, err))
+			continue
+		}
+		files = append(files, fileSpec{name: a.Filename, content: data})
+	}
+	return files, notes
+}
+
+// isImageAttachment reports whether the given attachment is an image (by
+// content-type, falling back to extension).
+func isImageAttachment(a *discordgo.MessageAttachment) bool {
+	if strings.HasPrefix(strings.ToLower(a.ContentType), "image/") {
+		return true
+	}
+	lower := strings.ToLower(a.Filename)
+	for _, ext := range []string{".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".heic", ".avif"} {
+		if strings.HasSuffix(lower, ext) {
+			return true
+		}
+	}
+	return false
+}
+
+// defaultFetchImage is the production implementation of the fetchImage
+// hook. Performs a single GET with a short timeout, validates that the
+// response looks like an image, and reads at most maxBytes.
+func defaultFetchImage(url string, maxBytes int) ([]byte, error) {
+	client := &http.Client{Timeout: 15 * time.Second}
+	resp, err := client.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("status %d", resp.StatusCode)
+	}
+	ct := strings.ToLower(resp.Header.Get("Content-Type"))
+	if ct != "" && !strings.HasPrefix(ct, "image/") {
+		return nil, fmt.Errorf("not an image: %s", ct)
+	}
+	// Read up to maxBytes+1 so we can detect oversize.
+	body, err := io.ReadAll(io.LimitReader(resp.Body, int64(maxBytes)+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(body) > maxBytes {
+		return nil, fmt.Errorf("image exceeds %d bytes", maxBytes)
+	}
+	return body, nil
 }

--- a/internal/commands/modules/nineteeneightyfour/nineteeneightyfour.go
+++ b/internal/commands/modules/nineteeneightyfour/nineteeneightyfour.go
@@ -1,0 +1,646 @@
+// Package nineteeneightyfour implements the "1984" audit module:
+// it logs every message create, edit, delete, and reaction add/remove across
+// every channel (except the configured 1984 log channel itself) to a single
+// audit channel. Designed to never fail on long content - anything too large
+// to inline is sent as a .txt file attachment.
+package nineteeneightyfour
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/bwmarrin/discordgo"
+	"github.com/pmezard/go-difflib/difflib"
+
+	"gamerpal/internal/commands/types"
+	"gamerpal/internal/config"
+)
+
+// voiceChannelStatusUpdateRawType is the discord gateway event name for voice
+// channel status updates. discordgo doesn't model this as a typed event so we
+// catch it via the raw event handler.
+const voiceChannelStatusUpdateRawType = "VOICE_CHANNEL_STATUS_UPDATE"
+
+// voiceChannelStatusUpdate is the JSON payload for a VOICE_CHANNEL_STATUS_UPDATE
+// gateway event. Not provided as a typed struct by discordgo v0.29.0.
+type voiceChannelStatusUpdate struct {
+	ID      string `json:"id"`
+	GuildID string `json:"guild_id"`
+	Status  string `json:"status"`
+}
+
+// Module implements the CommandModule interface but registers no slash
+// commands. Its work is done entirely via Discord event handlers wired up
+// from bot.go.
+type Module struct {
+	config *config.Config
+
+	// dispatchLog sends a fully-built payload to the given channel. Overridable
+	// in tests so handler logic can be exercised without hitting the network.
+	dispatchLog func(s *discordgo.Session, channelID string, p payload) error
+}
+
+// New creates a new 1984 module instance.
+func New(deps *types.Dependencies) *Module {
+	m := &Module{config: deps.Config}
+	m.dispatchLog = m.defaultDispatchLog
+	return m
+}
+
+// Register satisfies the CommandModule interface (no commands to register).
+func (m *Module) Register(_ map[string]*types.Command, deps *types.Dependencies) {
+	m.config = deps.Config
+	if m.dispatchLog == nil {
+		m.dispatchLog = m.defaultDispatchLog
+	}
+}
+
+// Service returns nil; this module has no recurring service.
+func (m *Module) Service() types.ModuleService { return nil }
+
+// ----------------------------------------------------------------------------
+// Event handlers - wired up from bot.go.
+// ----------------------------------------------------------------------------
+
+// OnMessageCreate logs every newly sent message.
+func (m *Module) OnMessageCreate(s *discordgo.Session, e *discordgo.MessageCreate) {
+	if e == nil || e.Message == nil {
+		return
+	}
+	if !m.shouldLog(s, e.GuildID, e.ChannelID, e.Author) {
+		return
+	}
+
+	channelName, isVoiceText := m.channelInfo(s, e.ChannelID)
+
+	header := buildHeader("📝 Message Sent", e.Author, e.ChannelID, channelName, e.ID, isVoiceText)
+	body := strings.TrimSpace(e.Content)
+	// A message create is worth logging if it has any user-visible payload:
+	// text, attachments, embeds, stickers, polls, or interactive components.
+	if body == "" && len(e.Attachments) == 0 && len(e.Embeds) == 0 &&
+		len(e.StickerItems) == 0 && e.Poll == nil && len(e.Components) == 0 {
+		return
+	}
+
+	parts := []string{header}
+	if body != "" {
+		parts = append(parts, "**Content:**", codeBlock(body))
+	}
+	if len(e.Attachments) > 0 {
+		parts = append(parts, fmt.Sprintf("**Attachments:** %d", len(e.Attachments)))
+	}
+	if len(e.StickerItems) > 0 {
+		parts = append(parts, fmt.Sprintf("**Stickers:** %d", len(e.StickerItems)))
+	}
+	if e.Poll != nil {
+		parts = append(parts, "**Poll:** yes")
+	}
+	if len(e.Components) > 0 {
+		parts = append(parts, fmt.Sprintf("**Components:** %d", len(e.Components)))
+	}
+
+	m.send(s, strings.Join(parts, "\n"), namedFile("content.txt", body))
+}
+
+// OnMessageUpdate logs message edits with a before/after view.
+//
+// MESSAGE_UPDATE is a partial gateway payload: unchanged fields can be
+// omitted. That means we cannot trust e.Content == "" as "cleared" and we
+// cannot trust e.Author == nil as "unknown". To avoid false positives:
+//   - we fall back to the cached author when the payload omits it
+//   - we require e.EditedTimestamp != nil, which Discord only sets on real
+//     user edits (embed unfurls and other system updates leave it nil)
+//   - we require a cached BeforeUpdate so before/after can actually be diffed
+func (m *Module) OnMessageUpdate(s *discordgo.Session, e *discordgo.MessageUpdate) {
+	if e == nil || e.Message == nil {
+		return
+	}
+	if e.BeforeUpdate == nil {
+		return
+	}
+	if e.EditedTimestamp == nil {
+		return
+	}
+
+	author := e.Author
+	if author == nil {
+		author = e.BeforeUpdate.Author
+	}
+	if author == nil {
+		return
+	}
+	if !m.shouldLog(s, e.GuildID, e.ChannelID, author) {
+		return
+	}
+
+	before := e.BeforeUpdate.Content
+	after := e.Content
+	if before == after {
+		return
+	}
+
+	channelName, isVoiceText := m.channelInfo(s, e.ChannelID)
+	header := buildHeader("✏️ Message Edited", author, e.ChannelID, channelName, e.ID, isVoiceText)
+
+	diff := renderUnifiedDiff(before, after)
+	parts := []string{
+		header,
+		"**Diff:**",
+		codeBlockLang("diff", diff),
+	}
+
+	m.send(s, strings.Join(parts, "\n"),
+		namedFile("before.txt", before),
+		namedFile("after.txt", after),
+		namedFile("diff.patch", diff),
+	)
+}
+
+// OnMessageDelete logs message deletions, including the deleted content when
+// it was cached.
+func (m *Module) OnMessageDelete(s *discordgo.Session, e *discordgo.MessageDelete) {
+	if e == nil || e.Message == nil {
+		return
+	}
+
+	// We may not know the author (uncached delete). Still skip if it's the
+	// log channel itself.
+	if !m.shouldLogChannel(e.ChannelID) {
+		return
+	}
+	if e.GuildID == "" {
+		return
+	}
+
+	var author *discordgo.User
+	var content string
+	if e.BeforeDelete != nil {
+		author = e.BeforeDelete.Author
+		content = e.BeforeDelete.Content
+	}
+	if author != nil && s.State != nil && s.State.User != nil && author.ID == s.State.User.ID {
+		return
+	}
+
+	channelName, isVoiceText := m.channelInfo(s, e.ChannelID)
+	header := buildHeader("🗑️ Message Deleted", author, e.ChannelID, channelName, e.ID, isVoiceText)
+
+	display := content
+	if e.BeforeDelete == nil {
+		display = "(message was not in cache; content unavailable)"
+	} else if content == "" {
+		display = "(no text content)"
+	}
+
+	parts := []string{
+		header,
+		"**Deleted content:**",
+		codeBlock(display),
+	}
+
+	m.send(s, strings.Join(parts, "\n"), namedFile("deleted.txt", display))
+}
+
+// OnMessageReactionAdd logs reactions being added.
+func (m *Module) OnMessageReactionAdd(s *discordgo.Session, e *discordgo.MessageReactionAdd) {
+	if e == nil || e.MessageReaction == nil {
+		return
+	}
+	m.logReaction(s, e.MessageReaction, e.Member, "➕ Reaction Added")
+}
+
+// OnMessageReactionRemove logs reactions being removed.
+func (m *Module) OnMessageReactionRemove(s *discordgo.Session, e *discordgo.MessageReactionRemove) {
+	if e == nil || e.MessageReaction == nil {
+		return
+	}
+	m.logReaction(s, e.MessageReaction, nil, "➖ Reaction Removed")
+}
+
+// OnChannelCreate logs the creation of voice/stage channels.
+func (m *Module) OnChannelCreate(s *discordgo.Session, e *discordgo.ChannelCreate) {
+	if e == nil || e.Channel == nil {
+		return
+	}
+	if e.GuildID == "" || !isVoiceLike(e.Type) {
+		return
+	}
+	if !m.shouldLogChannel(e.ID) {
+		return
+	}
+
+	header := buildChannelEventHeader("🔊 Voice Channel Created", e.ID, e.Name, channelTypeName(e.Type))
+	m.send(s, header)
+}
+
+// OnChannelUpdate logs voice/stage channel renames.
+//
+// CHANNEL_UPDATE fires for many non-rename changes (bitrate, user limit,
+// permissions, region, etc). Without a cached `BeforeUpdate` we cannot tell
+// whether the name changed, so we skip uncached updates rather than emit
+// false-positive rename logs.
+func (m *Module) OnChannelUpdate(s *discordgo.Session, e *discordgo.ChannelUpdate) {
+	if e == nil || e.Channel == nil {
+		return
+	}
+	if e.GuildID == "" || !isVoiceLike(e.Type) {
+		return
+	}
+	if !m.shouldLogChannel(e.ID) {
+		return
+	}
+	if e.BeforeUpdate == nil || e.BeforeUpdate.Name == e.Name {
+		return
+	}
+
+	header := buildChannelEventHeader("🔊 Voice Channel Renamed", e.ID, e.Name, channelTypeName(e.Type))
+	body := header + fmt.Sprintf("\n**Before:** `%s`\n**After:** `%s`", e.BeforeUpdate.Name, e.Name)
+	m.send(s, body)
+}
+
+// OnRawEvent receives every gateway event so we can catch ones discordgo
+// doesn't model as a typed event - currently only VOICE_CHANNEL_STATUS_UPDATE.
+func (m *Module) OnRawEvent(s *discordgo.Session, e *discordgo.Event) {
+	if e == nil || e.Type != voiceChannelStatusUpdateRawType {
+		return
+	}
+	var u voiceChannelStatusUpdate
+	if err := json.Unmarshal(e.RawData, &u); err != nil {
+		return
+	}
+	if u.GuildID == "" {
+		return
+	}
+	if !m.shouldLogChannel(u.ID) {
+		return
+	}
+
+	name, _ := m.channelInfo(s, u.ID)
+	if name == "" {
+		name = "(unknown)"
+	}
+	header := buildChannelEventHeader("🔊 Voice Channel Status Updated", u.ID, name, "voice")
+	display := u.Status
+	if display == "" {
+		display = "(cleared)"
+	}
+	body := header + "\n**Status:**\n" + codeBlock(display)
+	m.send(s, body, namedFile("status.txt", display))
+}
+
+// ----------------------------------------------------------------------------
+// Internals
+// ----------------------------------------------------------------------------
+
+func (m *Module) logReaction(s *discordgo.Session, r *discordgo.MessageReaction, member *discordgo.Member, title string) {
+	if r.GuildID == "" {
+		return
+	}
+	if !m.shouldLogChannel(r.ChannelID) {
+		return
+	}
+	if s.State != nil && s.State.User != nil && r.UserID == s.State.User.ID {
+		return
+	}
+
+	user := userFromMember(member)
+
+	channelName, isVoiceText := m.channelInfo(s, r.ChannelID)
+	header := buildHeader(title, user, r.ChannelID, channelName, r.MessageID, isVoiceText)
+	if user == nil {
+		header += fmt.Sprintf("\n**User ID:** `%s`", r.UserID)
+	}
+
+	emoji := r.Emoji.Name
+	if r.Emoji.ID != "" {
+		emoji = fmt.Sprintf("%s (`%s`)", r.Emoji.Name, r.Emoji.ID)
+	}
+
+	body := header + "\n**Emoji:** " + emoji
+	m.send(s, body)
+}
+
+// shouldLog returns true if this guild message should be logged.
+func (m *Module) shouldLog(s *discordgo.Session, guildID, channelID string, author *discordgo.User) bool {
+	if guildID == "" {
+		return false
+	}
+	if !m.shouldLogChannel(channelID) {
+		return false
+	}
+	if author != nil && s.State != nil && s.State.User != nil && author.ID == s.State.User.ID {
+		return false
+	}
+	return true
+}
+
+// shouldLogChannel returns false if logging is disabled or the channel is the
+// 1984 log channel itself (avoiding feedback loops).
+func (m *Module) shouldLogChannel(channelID string) bool {
+	logCh := m.config.GetGamerPals1984LogChannelID()
+	if logCh == "" {
+		return false
+	}
+	return channelID != logCh
+}
+
+// channelInfo fetches the channel name and whether the channel is the text
+// chat of a voice channel from the local state cache. We don't fall back to
+// REST here: if the channel isn't cached it almost certainly means we can't
+// see it, in which case "(unknown)" is the right value to log.
+func (m *Module) channelInfo(s *discordgo.Session, channelID string) (name string, isVoiceText bool) {
+	if s == nil || s.State == nil {
+		return "(unknown)", false
+	}
+	ch, err := s.State.Channel(channelID)
+	if err != nil || ch == nil {
+		return "(unknown)", false
+	}
+	return ch.Name, ch.Type == discordgo.ChannelTypeGuildVoice || ch.Type == discordgo.ChannelTypeGuildStageVoice
+}
+
+func userFromMember(m *discordgo.Member) *discordgo.User {
+	if m == nil {
+		return nil
+	}
+	return m.User
+}
+
+// isVoiceLike returns true for voice and stage voice channel types.
+func isVoiceLike(t discordgo.ChannelType) bool {
+	return t == discordgo.ChannelTypeGuildVoice || t == discordgo.ChannelTypeGuildStageVoice
+}
+
+// channelTypeName returns a short label for the given channel type. Used in
+// channel-event log headers.
+func channelTypeName(t discordgo.ChannelType) string {
+	switch t {
+	case discordgo.ChannelTypeGuildVoice:
+		return "voice"
+	case discordgo.ChannelTypeGuildStageVoice:
+		return "stage voice"
+	default:
+		return "channel"
+	}
+}
+
+// buildChannelEventHeader formats the standard log header for channel-level
+// events (creation, rename, status update). These don't have a user or
+// message ID associated with them.
+func buildChannelEventHeader(title, channelID, channelName, channelType string) string {
+	var b strings.Builder
+	b.WriteString("**")
+	b.WriteString(title)
+	b.WriteString("** - ")
+	b.WriteString(time.Now().UTC().Format(time.RFC3339))
+	b.WriteString("\n")
+	fmt.Fprintf(&b, "**Channel:** <#%s> `%s` (ID: `%s`) _[%s]_", channelID, channelName, channelID, channelType)
+	return b.String()
+}
+
+// buildHeader formats the standard log header with user, channel, and message
+// identifiers.
+func buildHeader(title string, author *discordgo.User, channelID, channelName, messageID string, isVoiceText bool) string {
+	var b strings.Builder
+	b.WriteString("**")
+	b.WriteString(title)
+	b.WriteString("** - ")
+	b.WriteString(time.Now().UTC().Format(time.RFC3339))
+	b.WriteString("\n")
+
+	if author != nil {
+		fmt.Fprintf(&b, "**User:** `%s` (ID: `%s`)\n", author.Username, author.ID)
+	} else {
+		b.WriteString("**User:** `(unknown)`\n")
+	}
+
+	suffix := ""
+	if isVoiceText {
+		suffix = " _(voice channel text chat)_"
+	}
+	fmt.Fprintf(&b, "**Channel:** <#%s> `%s` (ID: `%s`)%s", channelID, channelName, channelID, suffix)
+	if messageID != "" {
+		fmt.Fprintf(&b, "\n**Message ID:** `%s`", messageID)
+	}
+	return b.String()
+}
+
+// codeBlock renders content inside a fenced code block, truncating extreme
+// content so the code block itself stays under Discord's per-message cap.
+// Truncation respects UTF-8 rune boundaries so multi-byte characters
+// (emoji, CJK, etc.) are never split. The full content is always also
+// delivered as a file attachment by callers when appropriate.
+func codeBlock(s string) string {
+	return codeBlockLang("", s)
+}
+
+// codeBlockLang renders content inside a fenced code block tagged with the
+// given language identifier (e.g. "diff" for syntax-highlighted diffs).
+// Empty lang produces a plain fenced block. Same UTF-8 / length safety as
+// codeBlock.
+func codeBlockLang(lang, s string) string {
+	if s == "" {
+		return "```" + lang + "\n```"
+	}
+	display := s
+	if len(display) > inlineContentCap {
+		display = truncateUTF8(display, inlineContentCap) + "\n…(truncated, see attachment)"
+	}
+	// Neutralize embedded triple backticks so the fence isn't broken.
+	display = strings.ReplaceAll(display, "```", "ʼʼʼ")
+	return "```" + lang + "\n" + display + "\n```"
+}
+
+// truncateUTF8 returns s clipped to at most maxBytes bytes, backing up to the
+// nearest UTF-8 rune boundary so no rune is split.
+func truncateUTF8(s string, maxBytes int) string {
+	if maxBytes <= 0 {
+		return ""
+	}
+	if len(s) <= maxBytes {
+		return s
+	}
+	cut := maxBytes
+	for cut > 0 && !utf8.RuneStart(s[cut]) {
+		cut--
+	}
+	return s[:cut]
+}
+
+// renderUnifiedDiff produces a unified-diff string between before and after,
+// suitable for embedding inside a ```diff``` fenced code block. Returns the
+// empty string only if both inputs are equal.
+func renderUnifiedDiff(before, after string) string {
+	d := difflib.UnifiedDiff{
+		A:        difflib.SplitLines(before),
+		B:        difflib.SplitLines(after),
+		FromFile: "before",
+		ToFile:   "after",
+		Context:  3,
+	}
+	out, err := difflib.GetUnifiedDiffString(d)
+	if err != nil {
+		return ""
+	}
+	return out
+}
+
+// fileAttachment is a piece of content that may be attached if too long to inline.
+type fileAttachment struct {
+	name    string
+	content string
+}
+
+func namedFile(name, content string) fileAttachment {
+	return fileAttachment{name: name, content: content}
+}
+
+// Discord API limits we conservatively guard against.
+const (
+	// Discord's hard cap on message content is 2000 characters; we leave
+	// headroom for safety.
+	maxMessageContentChars = 1900
+	// Inline cap for fenced code-block bodies inside the message.
+	inlineContentCap = 1500
+	// Discord allows up to 10 attachments per message.
+	maxAttachmentsPerMessage = 10
+	// Per-attachment size cap (Discord's free upload limit is 10MB; we cap
+	// well below that to be safe).
+	maxAttachmentBytes = 8 * 1024 * 1024
+)
+
+// fileSpec describes a file to upload.
+type fileSpec struct {
+	name    string
+	content []byte
+}
+
+// payload is what would actually be sent to Discord. Pure result of
+// buildPayload, which keeps it easy to unit-test the limit-guard logic
+// without hitting the network.
+type payload struct {
+	content string
+	files   []fileSpec
+}
+
+// buildPayload turns a rendered message body and a set of optional
+// attachments into a Discord-safe payload that:
+//   - has content <= maxMessageContentChars
+//   - has at most maxAttachmentsPerMessage attachments
+//   - has every attachment <= maxAttachmentBytes
+//
+// Long attachments are uploaded as files; if the content itself is too
+// long it is moved into a log.txt file and the content becomes a short
+// pointer message.
+func buildPayload(content string, attachments []fileAttachment) payload {
+	var files []fileSpec
+	for _, a := range attachments {
+		if a.content == "" {
+			continue
+		}
+		if len(a.content) > inlineContentCap {
+			files = append(files, fileSpec{
+				name:    a.name,
+				content: clampBytes([]byte(a.content), maxAttachmentBytes),
+			})
+		}
+	}
+
+	if len(content) > maxMessageContentChars {
+		files = append(files, fileSpec{
+			name:    "log.txt",
+			content: clampBytes([]byte(content), maxAttachmentBytes),
+		})
+		content = "📋 Log entry attached (content too long to inline)."
+	}
+
+	if len(files) > maxAttachmentsPerMessage {
+		// Merge overflow files into a single combined.txt to stay within
+		// Discord's per-message attachment cap.
+		keep := files[:maxAttachmentsPerMessage-1]
+		overflow := files[maxAttachmentsPerMessage-1:]
+		var buf bytes.Buffer
+		for _, f := range overflow {
+			buf.WriteString("=== ")
+			buf.WriteString(f.name)
+			buf.WriteString(" ===\n")
+			buf.Write(f.content)
+			buf.WriteString("\n\n")
+		}
+		merged := fileSpec{
+			name:    "combined.txt",
+			content: clampBytes(buf.Bytes(), maxAttachmentBytes),
+		}
+		files = append(keep, merged)
+	}
+
+	return payload{content: content, files: files}
+}
+
+// clampBytes returns b unchanged if within max, otherwise truncates with a
+// trailing marker so the receiver knows truncation occurred. Truncation
+// respects UTF-8 rune boundaries (backs up if a cut would split a multi-byte
+// rune). If max is too small to hold even the marker, the output is just
+// truncated to max bytes (still rune-aligned) with no marker.
+func clampBytes(b []byte, max int) []byte {
+	if len(b) <= max {
+		return b
+	}
+	const marker = "\n…(truncated)\n"
+	if max <= len(marker) {
+		cut := max
+		for cut > 0 && !utf8.RuneStart(b[cut]) {
+			cut--
+		}
+		out := make([]byte, cut)
+		copy(out, b[:cut])
+		return out
+	}
+	cut := max - len(marker)
+	for cut > 0 && !utf8.RuneStart(b[cut]) {
+		cut--
+	}
+	out := make([]byte, 0, cut+len(marker))
+	out = append(out, b[:cut]...)
+	out = append(out, []byte(marker)...)
+	return out
+}
+
+// send posts the rendered message to the 1984 log channel. Any provided
+// attachments whose content exceeds the inline cap (or whose presence is
+// otherwise needed because the rendered message is itself too long) are
+// uploaded as files to guarantee logging never fails for long messages.
+func (m *Module) send(s *discordgo.Session, content string, attachments ...fileAttachment) {
+	channelID := m.config.GetGamerPals1984LogChannelID()
+	if channelID == "" {
+		return
+	}
+
+	p := buildPayload(content, attachments)
+	if err := m.dispatchLog(s, channelID, p); err != nil {
+		m.config.Logger.Warnf("1984: failed to send log message: %v", err)
+	}
+}
+
+// defaultDispatchLog is the production implementation of dispatchLog: build the
+// Discord file structures and POST via ChannelMessageSendComplex.
+func (m *Module) defaultDispatchLog(s *discordgo.Session, channelID string, p payload) error {
+	files := make([]*discordgo.File, 0, len(p.files))
+	for _, f := range p.files {
+		files = append(files, &discordgo.File{
+			Name:        f.name,
+			ContentType: "text/plain",
+			Reader:      bytes.NewReader(f.content),
+		})
+	}
+	_, err := s.ChannelMessageSendComplex(channelID, &discordgo.MessageSend{
+		Content:         p.content,
+		Files:           files,
+		AllowedMentions: &discordgo.MessageAllowedMentions{}, // never ping anyone from the log
+	})
+	return err
+}

--- a/internal/commands/modules/nineteeneightyfour/nineteeneightyfour_test.go
+++ b/internal/commands/modules/nineteeneightyfour/nineteeneightyfour_test.go
@@ -1,0 +1,1360 @@
+package nineteeneightyfour
+
+import (
+	"strings"
+	"sync"
+	"testing"
+	"time"
+	"unicode/utf8"
+
+	"github.com/bwmarrin/discordgo"
+
+	"gamerpal/internal/commands/types"
+	"gamerpal/internal/config"
+)
+
+const (
+	testLogChannelID = "LOG_CH"
+	testGuildID      = "G1"
+	testBotID        = "BOT"
+)
+
+var fakeUser = discordgo.User{Username: "alice", ID: "U42"}
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+// captured holds what the module would have sent to Discord. Built by
+// installing a stub dispatchLog in Module so handler logic can be exercised
+// without any network IO.
+type captured struct {
+	channelID string
+	payload   payload
+}
+
+type recorder struct {
+	mu   sync.Mutex
+	logs []captured
+}
+
+func (r *recorder) record(_ *discordgo.Session, channelID string, p payload) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.logs = append(r.logs, captured{channelID: channelID, payload: p})
+	return nil
+}
+
+// newTestModule builds a Module wired with a stub dispatchLog and a config
+// pre-set to use testLogChannelID. Returns the module and a recorder that
+// captures every dispatched payload.
+func newTestModule(t *testing.T) (*Module, *recorder) {
+	t.Helper()
+	cfg := config.NewMockConfig(map[string]interface{}{
+		"gamerpals_1984_log_channel_id": testLogChannelID,
+	})
+	m := New(&types.Dependencies{Config: cfg})
+	r := &recorder{}
+	m.dispatchLog = r.record
+	return m, r
+}
+
+// newTestSession returns a discordgo.Session that has just enough state for
+// our handlers: a populated State (so s.State.User and channel lookups work)
+// and a fake bot user. All channels are added under testGuildID.
+func newTestSession(channels ...*discordgo.Channel) *discordgo.Session {
+	s := &discordgo.Session{State: discordgo.NewState()}
+	s.State.User = &discordgo.User{ID: testBotID, Username: "bot"}
+	_ = s.State.GuildAdd(&discordgo.Guild{ID: testGuildID})
+	for _, c := range channels {
+		if c.GuildID == "" {
+			c.GuildID = testGuildID
+		}
+		_ = s.State.ChannelAdd(c)
+	}
+	return s
+}
+
+func textChannel(id, name string) *discordgo.Channel {
+	return &discordgo.Channel{ID: id, Name: name, Type: discordgo.ChannelTypeGuildText}
+}
+
+func voiceChannel(id, name string) *discordgo.Channel {
+	return &discordgo.Channel{ID: id, Name: name, Type: discordgo.ChannelTypeGuildVoice}
+}
+
+// assertPayloadWithinLimits enforces the Discord-side guarantees we promise:
+// content fits in a Discord message, attachment count fits, each attachment
+// fits, and no attachment has an empty name.
+func assertPayloadWithinLimits(t *testing.T, p payload) {
+	t.Helper()
+	if len(p.content) > maxMessageContentChars {
+		t.Errorf("content length %d exceeds maxMessageContentChars %d", len(p.content), maxMessageContentChars)
+	}
+	if len(p.content) > 2000 {
+		t.Errorf("content length %d exceeds Discord hard limit 2000", len(p.content))
+	}
+	if len(p.files) > maxAttachmentsPerMessage {
+		t.Errorf("file count %d exceeds maxAttachmentsPerMessage %d", len(p.files), maxAttachmentsPerMessage)
+	}
+	for _, f := range p.files {
+		if len(f.content) > maxAttachmentBytes {
+			t.Errorf("file %s size %d exceeds maxAttachmentBytes %d", f.name, len(f.content), maxAttachmentBytes)
+		}
+		if f.name == "" {
+			t.Errorf("file has empty name")
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers
+// ---------------------------------------------------------------------------
+
+func TestCodeBlock(t *testing.T) {
+	tests := []struct {
+		name          string
+		input         string
+		wantTruncated bool
+		wantNoFences  bool
+		wantMaxLen    int
+	}{
+		{name: "empty input renders fences", input: ""},
+		{name: "short input is unchanged inside fences", input: "hello"},
+		{
+			name:          "long input is truncated",
+			input:         strings.Repeat("x", 5000),
+			wantTruncated: true,
+			wantMaxLen:    inlineContentCap + 128,
+		},
+		{
+			name:         "embedded triple backticks are neutralized",
+			input:        "before ``` middle ``` after",
+			wantNoFences: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out := codeBlock(tt.input)
+			if !strings.HasPrefix(out, "```") || !strings.HasSuffix(out, "```") {
+				t.Errorf("missing outer fence: %q", out)
+			}
+			if tt.wantTruncated && !strings.Contains(out, "truncated") {
+				t.Errorf("expected truncation marker, got len=%d", len(out))
+			}
+			if tt.wantMaxLen > 0 && len(out) > tt.wantMaxLen {
+				t.Errorf("output longer than expected: %d > %d", len(out), tt.wantMaxLen)
+			}
+			if tt.wantNoFences {
+				inner := out[3 : len(out)-3]
+				if strings.Contains(inner, "```") {
+					t.Errorf("inner content still contains ```: %q", out)
+				}
+			}
+		})
+	}
+}
+
+func TestClampBytes(t *testing.T) {
+	tests := []struct {
+		name       string
+		size       int
+		max        int
+		wantLen    int
+		wantMarker bool
+	}{
+		{name: "under limit unchanged", size: 100, max: 200, wantLen: 100},
+		{name: "exactly at limit unchanged", size: 200, max: 200, wantLen: 200},
+		{name: "over limit truncated with marker", size: 1000, max: 200, wantLen: 200, wantMarker: true},
+		{name: "max smaller than marker still respected", size: 1000, max: 5, wantLen: 5, wantMarker: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out := clampBytes([]byte(strings.Repeat("a", tt.size)), tt.max)
+			if len(out) > tt.max {
+				t.Errorf("len(out)=%d exceeds max %d", len(out), tt.max)
+			}
+			if len(out) != tt.wantLen {
+				t.Errorf("len(out)=%d want %d", len(out), tt.wantLen)
+			}
+			if tt.wantMarker && !strings.Contains(string(out), "truncated") {
+				t.Errorf("expected truncation marker")
+			}
+		})
+	}
+}
+
+func TestUserFromMember(t *testing.T) {
+	tests := []struct {
+		name string
+		in   *discordgo.Member
+		want *discordgo.User
+	}{
+		{name: "nil member", in: nil, want: nil},
+		{name: "member with user", in: &discordgo.Member{User: &fakeUser}, want: &fakeUser},
+		{name: "member with nil user", in: &discordgo.Member{}, want: nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := userFromMember(tt.in); got != tt.want {
+				t.Errorf("got %v want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNamedFile(t *testing.T) {
+	a := namedFile("x.txt", "hello")
+	if a.name != "x.txt" || a.content != "hello" {
+		t.Errorf("unexpected: %+v", a)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Module gating helpers
+// ---------------------------------------------------------------------------
+
+func TestShouldLogChannel(t *testing.T) {
+	tests := []struct {
+		name      string
+		logChan   string
+		channelID string
+		want      bool
+	}{
+		{name: "logging disabled (no channel configured)", logChan: "", channelID: "C1", want: false},
+		{name: "regular channel logs", logChan: "LOG", channelID: "C1", want: true},
+		{name: "the log channel itself is skipped", logChan: "LOG", channelID: "LOG", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := config.NewMockConfig(map[string]interface{}{
+				"gamerpals_1984_log_channel_id": tt.logChan,
+			})
+			m := New(&types.Dependencies{Config: cfg})
+			if got := m.shouldLogChannel(tt.channelID); got != tt.want {
+				t.Errorf("got %v want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestShouldLog(t *testing.T) {
+	s := newTestSession()
+	tests := []struct {
+		name      string
+		guildID   string
+		channelID string
+		author    *discordgo.User
+		want      bool
+	}{
+		{name: "DM (no guild) is skipped", guildID: "", channelID: "C1", author: &fakeUser, want: false},
+		{name: "log channel itself is skipped", guildID: testGuildID, channelID: testLogChannelID, author: &fakeUser, want: false},
+		{name: "bot author is skipped", guildID: testGuildID, channelID: "C1", author: &discordgo.User{ID: testBotID}, want: false},
+		{name: "nil author still logs", guildID: testGuildID, channelID: "C1", author: nil, want: true},
+		{name: "regular guild message logs", guildID: testGuildID, channelID: "C1", author: &fakeUser, want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m, _ := newTestModule(t)
+			if got := m.shouldLog(s, tt.guildID, tt.channelID, tt.author); got != tt.want {
+				t.Errorf("got %v want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestChannelInfo(t *testing.T) {
+	s := newTestSession(
+		textChannel("C1", "general"),
+		voiceChannel("V1", "lobby"),
+	)
+	tests := []struct {
+		name        string
+		channelID   string
+		wantName    string
+		wantIsVoice bool
+	}{
+		{name: "text channel", channelID: "C1", wantName: "general", wantIsVoice: false},
+		{name: "voice channel text chat", channelID: "V1", wantName: "lobby", wantIsVoice: true},
+		{name: "unknown channel", channelID: "ZZZ", wantName: "(unknown)", wantIsVoice: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m, _ := newTestModule(t)
+			name, isVoice := m.channelInfo(s, tt.channelID)
+			if name != tt.wantName {
+				t.Errorf("name=%q want %q", name, tt.wantName)
+			}
+			if isVoice != tt.wantIsVoice {
+				t.Errorf("isVoice=%v want %v", isVoice, tt.wantIsVoice)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Payload builder
+// ---------------------------------------------------------------------------
+
+func TestBuildPayload(t *testing.T) {
+	longAttachment := strings.Repeat("a", inlineContentCap+1)
+	hugeContent := strings.Repeat("y", maxMessageContentChars+500)
+	overSizedAttachment := strings.Repeat("Z", 20*1024*1024)
+	overflowAttachments := func() []fileAttachment {
+		long := strings.Repeat("q", inlineContentCap+10)
+		out := make([]fileAttachment, 0, maxAttachmentsPerMessage+5)
+		for i := 0; i < maxAttachmentsPerMessage+5; i++ {
+			out = append(out, fileAttachment{name: "a.txt", content: long})
+		}
+		return out
+	}()
+
+	tests := []struct {
+		name              string
+		content           string
+		attachments       []fileAttachment
+		wantContentEquals string
+		wantContentSubstr string
+		wantFileCount     int
+		wantFirstFileName string
+		wantLastFileName  string
+		wantFirstFileEq   string
+	}{
+		{
+			name:              "short content, no attachments",
+			content:           "hello world",
+			wantContentEquals: "hello world",
+		},
+		{
+			name:        "short attachment is not uploaded",
+			content:     "hi",
+			attachments: []fileAttachment{{name: "x.txt", content: "tiny"}},
+		},
+		{
+			name:              "empty attachment ignored",
+			content:           "hi",
+			attachments:       []fileAttachment{{name: "x.txt", content: ""}},
+			wantContentEquals: "hi",
+		},
+		{
+			name:              "long attachment is uploaded",
+			content:           "header",
+			attachments:       []fileAttachment{{name: "content.txt", content: longAttachment}},
+			wantFileCount:     1,
+			wantFirstFileName: "content.txt",
+			wantFirstFileEq:   longAttachment,
+		},
+		{
+			name:              "oversized content is moved to log.txt",
+			content:           hugeContent,
+			wantFileCount:     1,
+			wantFirstFileName: "log.txt",
+			wantContentSubstr: "attached",
+		},
+		{
+			name:              "20MB attachment is clamped to maxAttachmentBytes",
+			content:           "header",
+			attachments:       []fileAttachment{{name: "huge.txt", content: overSizedAttachment}},
+			wantFileCount:     1,
+			wantFirstFileName: "huge.txt",
+		},
+		{
+			name:             "too many large attachments are merged into combined.txt",
+			content:          "header",
+			attachments:      overflowAttachments,
+			wantFileCount:    maxAttachmentsPerMessage,
+			wantLastFileName: "combined.txt",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := buildPayload(tt.content, tt.attachments)
+			assertPayloadWithinLimits(t, p)
+
+			if tt.wantContentEquals != "" && p.content != tt.wantContentEquals {
+				t.Errorf("content = %q, want %q", p.content, tt.wantContentEquals)
+			}
+			if tt.wantContentSubstr != "" && !strings.Contains(p.content, tt.wantContentSubstr) {
+				t.Errorf("content %q missing substr %q", p.content, tt.wantContentSubstr)
+			}
+			if len(p.files) != tt.wantFileCount {
+				t.Fatalf("file count = %d, want %d", len(p.files), tt.wantFileCount)
+			}
+			if tt.wantFirstFileName != "" && p.files[0].name != tt.wantFirstFileName {
+				t.Errorf("first file name = %q, want %q", p.files[0].name, tt.wantFirstFileName)
+			}
+			if tt.wantLastFileName != "" {
+				last := p.files[len(p.files)-1]
+				if last.name != tt.wantLastFileName {
+					t.Errorf("last file name = %q, want %q", last.name, tt.wantLastFileName)
+				}
+			}
+			if tt.wantFirstFileEq != "" && string(p.files[0].content) != tt.wantFirstFileEq {
+				t.Errorf("first file content was modified")
+			}
+		})
+	}
+}
+
+// TestBuildPayloadStress sweeps a wide combinatorial range of content and
+// attachment sizes and counts, asserting that buildPayload always produces
+// output within Discord's limits.
+func TestBuildPayloadStress(t *testing.T) {
+	contentSizes := []int{
+		0, 1, 100,
+		inlineContentCap - 1, inlineContentCap, inlineContentCap + 1,
+		maxMessageContentChars - 1, maxMessageContentChars, maxMessageContentChars + 1,
+		10_000, 100_000, 1_000_000,
+	}
+	attSizes := []int{
+		0, 1,
+		inlineContentCap, inlineContentCap + 1,
+		100_000,
+		maxAttachmentBytes - 1, maxAttachmentBytes, maxAttachmentBytes + 1,
+		20 * 1024 * 1024,
+	}
+	attCounts := []int{
+		0, 1, 3,
+		maxAttachmentsPerMessage,
+		maxAttachmentsPerMessage + 1,
+		maxAttachmentsPerMessage * 3,
+	}
+
+	for _, cSize := range contentSizes {
+		for _, aSize := range attSizes {
+			for _, n := range attCounts {
+				content := strings.Repeat("c", cSize)
+				atts := make([]fileAttachment, 0, n)
+				for i := 0; i < n; i++ {
+					atts = append(atts, fileAttachment{
+						name:    "f.txt",
+						content: strings.Repeat("a", aSize),
+					})
+				}
+				p := buildPayload(content, atts)
+				assertPayloadWithinLimits(t, p)
+			}
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Header rendering
+// ---------------------------------------------------------------------------
+
+func TestBuildHeader(t *testing.T) {
+	tests := []struct {
+		name        string
+		title       string
+		author      *discordgo.User
+		channelID   string
+		channelName string
+		messageID   string
+		isVoiceText bool
+		wantSubstrs []string
+		notSubstrs  []string
+	}{
+		{
+			name:        "voice text marker is included",
+			title:       "X",
+			channelID:   "1",
+			channelName: "general",
+			messageID:   "9",
+			isVoiceText: true,
+			wantSubstrs: []string{"voice channel text chat", "1", "9"},
+		},
+		{
+			name:        "user, channel, and message ids are included",
+			title:       "📝 Message Sent",
+			author:      &fakeUser,
+			channelID:   "C123",
+			channelName: "general",
+			messageID:   "M999",
+			wantSubstrs: []string{"alice", "U42", "C123", "M999", "general"},
+			notSubstrs:  []string{"voice channel text chat"},
+		},
+		{
+			name:        "missing author renders unknown placeholder",
+			title:       "🗑️ Message Deleted",
+			channelID:   "C7",
+			channelName: "lobby",
+			messageID:   "M8",
+			wantSubstrs: []string{"(unknown)", "C7", "M8"},
+		},
+		{
+			name:        "missing message id is omitted",
+			title:       "X",
+			author:      &fakeUser,
+			channelID:   "C1",
+			channelName: "general",
+			wantSubstrs: []string{"alice", "C1"},
+			notSubstrs:  []string{"Message ID"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out := buildHeader(tt.title, tt.author, tt.channelID, tt.channelName, tt.messageID, tt.isVoiceText)
+			for _, s := range tt.wantSubstrs {
+				if !strings.Contains(out, s) {
+					t.Errorf("expected substring %q in header: %q", s, out)
+				}
+			}
+			for _, s := range tt.notSubstrs {
+				if strings.Contains(out, s) {
+					t.Errorf("did not expect substring %q in header: %q", s, out)
+				}
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Event handlers (driven through the dispatchLog hook)
+// ---------------------------------------------------------------------------
+
+func TestOnMessageCreate(t *testing.T) {
+	tests := []struct {
+		name        string
+		guildID     string
+		channelID   string
+		author      *discordgo.User
+		content     string
+		attachments []*discordgo.MessageAttachment
+		wantLogged  bool
+		wantSubstrs []string
+	}{
+		{name: "regular message logs content", guildID: testGuildID, channelID: "C1", author: &fakeUser, content: "hello world", wantLogged: true, wantSubstrs: []string{"Message Sent", "alice", "hello world"}},
+		{name: "DM is skipped", guildID: "", channelID: "C1", author: &fakeUser, content: "hi", wantLogged: false},
+		{name: "log channel itself is skipped", guildID: testGuildID, channelID: testLogChannelID, author: &fakeUser, content: "hi", wantLogged: false},
+		{name: "bot's own message is skipped", guildID: testGuildID, channelID: "C1", author: &discordgo.User{ID: testBotID}, content: "hi", wantLogged: false},
+		{name: "empty message with no attachments/embeds is skipped", guildID: testGuildID, channelID: "C1", author: &fakeUser, content: "", wantLogged: false},
+		{name: "empty content with attachments still logs", guildID: testGuildID, channelID: "C1", author: &fakeUser, content: "", attachments: []*discordgo.MessageAttachment{{Filename: "x.png"}}, wantLogged: true, wantSubstrs: []string{"**Attachments:** 1"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m, r := newTestModule(t)
+			s := newTestSession(textChannel("C1", "general"))
+			m.OnMessageCreate(s, &discordgo.MessageCreate{Message: &discordgo.Message{
+				ID:          "M1",
+				ChannelID:   tt.channelID,
+				GuildID:     tt.guildID,
+				Author:      tt.author,
+				Content:     tt.content,
+				Attachments: tt.attachments,
+			}})
+			if got := len(r.logs) > 0; got != tt.wantLogged {
+				t.Fatalf("logged=%v want %v (logs=%d)", got, tt.wantLogged, len(r.logs))
+			}
+			if !tt.wantLogged {
+				return
+			}
+			assertPayloadWithinLimits(t, r.logs[0].payload)
+			if r.logs[0].channelID != testLogChannelID {
+				t.Errorf("logged to wrong channel: %s", r.logs[0].channelID)
+			}
+			for _, sub := range tt.wantSubstrs {
+				if !strings.Contains(r.logs[0].payload.content, sub) {
+					t.Errorf("missing %q in logged content:\n%s", sub, r.logs[0].payload.content)
+				}
+			}
+		})
+	}
+}
+
+func TestOnMessageCreate_LongMessageAttachesFile(t *testing.T) {
+	m, r := newTestModule(t)
+	s := newTestSession(textChannel("C1", "general"))
+	long := strings.Repeat("X", inlineContentCap*3)
+	m.OnMessageCreate(s, &discordgo.MessageCreate{Message: &discordgo.Message{
+		ID: "M1", ChannelID: "C1", GuildID: testGuildID, Author: &fakeUser, Content: long,
+	}})
+	if len(r.logs) != 1 {
+		t.Fatalf("want 1 log got %d", len(r.logs))
+	}
+	p := r.logs[0].payload
+	assertPayloadWithinLimits(t, p)
+	if len(p.files) == 0 {
+		t.Fatalf("expected an attachment for long content")
+	}
+	if !strings.Contains(string(p.files[0].content), "XXXX") {
+		t.Errorf("attachment didn't contain original content")
+	}
+}
+
+func TestOnMessageUpdate(t *testing.T) {
+	editTime := time.Now()
+	tests := []struct {
+		name       string
+		before     *discordgo.Message
+		guildID    string
+		channelID  string
+		author     *discordgo.User
+		content    string
+		edited     *time.Time
+		wantLogged bool
+		wantSubs   []string
+	}{
+		{
+			name:    "edited message with cached before logs diff",
+			before:  &discordgo.Message{Content: "old text", Author: &fakeUser},
+			guildID: testGuildID, channelID: "C1", author: &fakeUser, content: "new text",
+			edited:     &editTime,
+			wantLogged: true,
+			wantSubs:   []string{"Edited", "old text", "new text"},
+		},
+		{
+			name:    "no cached before is skipped (cannot verify content changed)",
+			before:  nil,
+			guildID: testGuildID, channelID: "C1", author: &fakeUser, content: "new text",
+			edited:     &editTime,
+			wantLogged: false,
+		},
+		{
+			name:    "unchanged content (embed update) is skipped",
+			before:  &discordgo.Message{Content: "same", Author: &fakeUser},
+			guildID: testGuildID, channelID: "C1", author: &fakeUser, content: "same",
+			edited:     &editTime,
+			wantLogged: false,
+		},
+		{
+			name:    "nil EditedTimestamp (embed unfurl) is skipped",
+			before:  &discordgo.Message{Content: "old", Author: &fakeUser},
+			guildID: testGuildID, channelID: "C1", author: &fakeUser, content: "new",
+			edited:     nil,
+			wantLogged: false,
+		},
+		{
+			name:    "partial payload omitting author falls back to cached author",
+			before:  &discordgo.Message{Content: "old", Author: &fakeUser},
+			guildID: testGuildID, channelID: "C1", author: nil, content: "new",
+			edited:     &editTime,
+			wantLogged: true,
+			wantSubs:   []string{"Edited", "alice", "old", "new"},
+		},
+		{
+			name:    "no author anywhere is skipped",
+			before:  &discordgo.Message{Content: "old"},
+			guildID: testGuildID, channelID: "C1", author: nil, content: "new",
+			edited:     &editTime,
+			wantLogged: false,
+		},
+		{
+			name:    "log channel itself is skipped",
+			before:  &discordgo.Message{Content: "x", Author: &fakeUser},
+			guildID: testGuildID, channelID: testLogChannelID, author: &fakeUser, content: "y",
+			edited:     &editTime,
+			wantLogged: false,
+		},
+		{
+			name:    "bot's own edit is skipped",
+			before:  &discordgo.Message{Content: "x", Author: &discordgo.User{ID: testBotID}},
+			guildID: testGuildID, channelID: "C1", author: &discordgo.User{ID: testBotID}, content: "y",
+			edited:     &editTime,
+			wantLogged: false,
+		},
+		{
+			name:    "DM edit is skipped",
+			before:  &discordgo.Message{Content: "x", Author: &fakeUser},
+			guildID: "", channelID: "C1", author: &fakeUser, content: "y",
+			edited:     &editTime,
+			wantLogged: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m, r := newTestModule(t)
+			s := newTestSession(textChannel("C1", "general"))
+			m.OnMessageUpdate(s, &discordgo.MessageUpdate{
+				Message: &discordgo.Message{
+					ID: "M1", ChannelID: tt.channelID, GuildID: tt.guildID,
+					Author: tt.author, Content: tt.content,
+					EditedTimestamp: tt.edited,
+				},
+				BeforeUpdate: tt.before,
+			})
+			if got := len(r.logs) > 0; got != tt.wantLogged {
+				t.Fatalf("logged=%v want %v", got, tt.wantLogged)
+			}
+			if !tt.wantLogged {
+				return
+			}
+			assertPayloadWithinLimits(t, r.logs[0].payload)
+			for _, sub := range tt.wantSubs {
+				if !strings.Contains(r.logs[0].payload.content, sub) {
+					t.Errorf("missing %q in logged content:\n%s", sub, r.logs[0].payload.content)
+				}
+			}
+		})
+	}
+}
+
+func TestOnMessageDelete(t *testing.T) {
+	tests := []struct {
+		name       string
+		before     *discordgo.Message
+		guildID    string
+		channelID  string
+		wantLogged bool
+		wantSubs   []string
+	}{
+		{
+			name:    "cached delete shows content and author",
+			before:  &discordgo.Message{Content: "secret", Author: &fakeUser},
+			guildID: testGuildID, channelID: "C1",
+			wantLogged: true,
+			wantSubs:   []string{"Deleted", "alice", "secret"},
+		},
+		{
+			name:    "uncached delete logs placeholder",
+			before:  nil,
+			guildID: testGuildID, channelID: "C1",
+			wantLogged: true,
+			wantSubs:   []string{"Deleted", "(unknown)", "not in cache"},
+		},
+		{
+			name:    "delete with empty content notes no text",
+			before:  &discordgo.Message{Content: "", Author: &fakeUser},
+			guildID: testGuildID, channelID: "C1",
+			wantLogged: true,
+			wantSubs:   []string{"no text content"},
+		},
+		{
+			name:    "DM delete is skipped",
+			before:  &discordgo.Message{Content: "x", Author: &fakeUser},
+			guildID: "", channelID: "C1",
+			wantLogged: false,
+		},
+		{
+			name:    "log channel delete is skipped",
+			before:  &discordgo.Message{Content: "x", Author: &fakeUser},
+			guildID: testGuildID, channelID: testLogChannelID,
+			wantLogged: false,
+		},
+		{
+			name:    "bot's own deleted message is skipped",
+			before:  &discordgo.Message{Content: "x", Author: &discordgo.User{ID: testBotID}},
+			guildID: testGuildID, channelID: "C1",
+			wantLogged: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m, r := newTestModule(t)
+			s := newTestSession(textChannel("C1", "general"))
+			m.OnMessageDelete(s, &discordgo.MessageDelete{
+				Message: &discordgo.Message{
+					ID: "M1", ChannelID: tt.channelID, GuildID: tt.guildID,
+				},
+				BeforeDelete: tt.before,
+			})
+			if got := len(r.logs) > 0; got != tt.wantLogged {
+				t.Fatalf("logged=%v want %v", got, tt.wantLogged)
+			}
+			if !tt.wantLogged {
+				return
+			}
+			assertPayloadWithinLimits(t, r.logs[0].payload)
+			for _, sub := range tt.wantSubs {
+				if !strings.Contains(r.logs[0].payload.content, sub) {
+					t.Errorf("missing %q in logged content:\n%s", sub, r.logs[0].payload.content)
+				}
+			}
+		})
+	}
+}
+
+func TestOnMessageReactionAdd_Remove(t *testing.T) {
+	tests := []struct {
+		name       string
+		op         string // "add" or "remove"
+		guildID    string
+		channelID  string
+		userID     string
+		emojiName  string
+		emojiID    string
+		member     *discordgo.Member
+		wantLogged bool
+		wantSubs   []string
+	}{
+		{
+			name: "add unicode emoji with member",
+			op:   "add", guildID: testGuildID, channelID: "C1", userID: "U42",
+			emojiName:  "🔥",
+			member:     &discordgo.Member{User: &fakeUser},
+			wantLogged: true, wantSubs: []string{"Reaction Added", "alice", "🔥"},
+		},
+		{
+			name: "add custom emoji shows id",
+			op:   "add", guildID: testGuildID, channelID: "C1", userID: "U42",
+			emojiName: "doge", emojiID: "E1",
+			member:     &discordgo.Member{User: &fakeUser},
+			wantLogged: true, wantSubs: []string{"Reaction Added", "doge", "E1"},
+		},
+		{
+			name: "remove emoji",
+			op:   "remove", guildID: testGuildID, channelID: "C1", userID: "U42",
+			emojiName:  "👍",
+			wantLogged: true, wantSubs: []string{"Reaction Removed", "👍"},
+		},
+		{
+			name: "DM reaction is skipped",
+			op:   "add", guildID: "", channelID: "C1", userID: "U42",
+			emojiName: "🔥", member: &discordgo.Member{User: &fakeUser},
+			wantLogged: false,
+		},
+		{
+			name: "log channel reaction is skipped",
+			op:   "add", guildID: testGuildID, channelID: testLogChannelID, userID: "U42",
+			emojiName: "🔥", member: &discordgo.Member{User: &fakeUser},
+			wantLogged: false,
+		},
+		{
+			name: "bot's own reaction is skipped",
+			op:   "add", guildID: testGuildID, channelID: "C1", userID: testBotID,
+			emojiName:  "🔥",
+			wantLogged: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m, r := newTestModule(t)
+			s := newTestSession(textChannel("C1", "general"))
+			mr := &discordgo.MessageReaction{
+				UserID:    tt.userID,
+				MessageID: "M1",
+				ChannelID: tt.channelID,
+				GuildID:   tt.guildID,
+				Emoji:     discordgo.Emoji{Name: tt.emojiName, ID: tt.emojiID},
+			}
+			switch tt.op {
+			case "add":
+				m.OnMessageReactionAdd(s, &discordgo.MessageReactionAdd{MessageReaction: mr, Member: tt.member})
+			case "remove":
+				m.OnMessageReactionRemove(s, &discordgo.MessageReactionRemove{MessageReaction: mr})
+			}
+			if got := len(r.logs) > 0; got != tt.wantLogged {
+				t.Fatalf("logged=%v want %v", got, tt.wantLogged)
+			}
+			if !tt.wantLogged {
+				return
+			}
+			assertPayloadWithinLimits(t, r.logs[0].payload)
+			for _, sub := range tt.wantSubs {
+				if !strings.Contains(r.logs[0].payload.content, sub) {
+					t.Errorf("missing %q in logged content:\n%s", sub, r.logs[0].payload.content)
+				}
+			}
+		})
+	}
+}
+
+func TestSend_NoLogChannelConfiguredIsNoOp(t *testing.T) {
+	cfg := config.NewMockConfig(map[string]interface{}{}) // no log channel
+	m := New(&types.Dependencies{Config: cfg})
+	r := &recorder{}
+	m.dispatchLog = r.record
+	m.send(nil, "anything")
+	if len(r.logs) != 0 {
+		t.Errorf("expected no dispatchLog when log channel unset, got %d", len(r.logs))
+	}
+}
+
+func TestNilEventsAreSafe(t *testing.T) {
+	m, r := newTestModule(t)
+	s := newTestSession()
+	// Each handler should tolerate fully-nil events without panicking or logging.
+	m.OnMessageCreate(s, nil)
+	m.OnMessageCreate(s, &discordgo.MessageCreate{})
+	m.OnMessageUpdate(s, nil)
+	m.OnMessageUpdate(s, &discordgo.MessageUpdate{})
+	m.OnMessageDelete(s, nil)
+	m.OnMessageDelete(s, &discordgo.MessageDelete{})
+	m.OnMessageReactionAdd(s, nil)
+	m.OnMessageReactionAdd(s, &discordgo.MessageReactionAdd{})
+	m.OnMessageReactionRemove(s, nil)
+	m.OnMessageReactionRemove(s, &discordgo.MessageReactionRemove{})
+	if len(r.logs) != 0 {
+		t.Errorf("expected no logs from nil/empty events, got %d", len(r.logs))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Module wiring
+// ---------------------------------------------------------------------------
+
+func TestModuleService_IsNil(t *testing.T) {
+	m, _ := newTestModule(t)
+	if m.Service() != nil {
+		t.Errorf("Service should be nil")
+	}
+}
+
+func TestModuleRegister_RegistersNoCommands(t *testing.T) {
+	m, _ := newTestModule(t)
+	cmds := map[string]*types.Command{}
+	m.Register(cmds, &types.Dependencies{Config: m.config})
+	if len(cmds) != 0 {
+		t.Errorf("expected zero commands registered, got %d", len(cmds))
+	}
+	if m.dispatchLog == nil {
+		t.Errorf("Register must leave dispatchLog installed")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Channel-level handlers (creation, rename, status update)
+// ---------------------------------------------------------------------------
+
+func TestOnChannelCreate(t *testing.T) {
+	tests := []struct {
+		name        string
+		channel     *discordgo.Channel
+		guildID     string
+		wantLogged  bool
+		wantSubstrs []string
+	}{
+		{
+			name:        "voice channel logs",
+			channel:     &discordgo.Channel{ID: "VC1", Name: "general-voice", Type: discordgo.ChannelTypeGuildVoice},
+			guildID:     testGuildID,
+			wantLogged:  true,
+			wantSubstrs: []string{"Voice Channel Created", "general-voice", "VC1", "[voice]"},
+		},
+		{
+			name:        "stage voice channel logs",
+			channel:     &discordgo.Channel{ID: "ST1", Name: "main-stage", Type: discordgo.ChannelTypeGuildStageVoice},
+			guildID:     testGuildID,
+			wantLogged:  true,
+			wantSubstrs: []string{"main-stage", "[stage voice]"},
+		},
+		{
+			name:       "text channel is skipped",
+			channel:    &discordgo.Channel{ID: "C1", Name: "general", Type: discordgo.ChannelTypeGuildText},
+			guildID:    testGuildID,
+			wantLogged: false,
+		},
+		{
+			name:       "DM channel is skipped",
+			channel:    &discordgo.Channel{ID: "VC1", Name: "x", Type: discordgo.ChannelTypeGuildVoice},
+			guildID:    "",
+			wantLogged: false,
+		},
+		{
+			name:       "log channel itself is skipped",
+			channel:    &discordgo.Channel{ID: testLogChannelID, Name: "logs", Type: discordgo.ChannelTypeGuildVoice},
+			guildID:    testGuildID,
+			wantLogged: false,
+		},
+		{
+			name:       "nil channel is skipped",
+			channel:    nil,
+			guildID:    testGuildID,
+			wantLogged: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m, r := newTestModule(t)
+			s := newTestSession()
+			e := &discordgo.ChannelCreate{Channel: tt.channel}
+			if tt.channel != nil {
+				tt.channel.GuildID = tt.guildID
+			}
+			m.OnChannelCreate(s, e)
+			if got := len(r.logs) > 0; got != tt.wantLogged {
+				t.Fatalf("logged=%v want %v (logs=%d)", got, tt.wantLogged, len(r.logs))
+			}
+			if !tt.wantLogged {
+				return
+			}
+			assertPayloadWithinLimits(t, r.logs[0].payload)
+			for _, sub := range tt.wantSubstrs {
+				if !strings.Contains(r.logs[0].payload.content, sub) {
+					t.Errorf("missing %q in:\n%s", sub, r.logs[0].payload.content)
+				}
+			}
+		})
+	}
+}
+
+func TestOnChannelCreate_NilEvent(t *testing.T) {
+	m, r := newTestModule(t)
+	s := newTestSession()
+	m.OnChannelCreate(s, nil)
+	if len(r.logs) != 0 {
+		t.Fatalf("expected no log on nil event, got %d", len(r.logs))
+	}
+}
+
+func TestOnChannelUpdate(t *testing.T) {
+	voiceCh := func(id, name string) *discordgo.Channel {
+		return &discordgo.Channel{ID: id, Name: name, Type: discordgo.ChannelTypeGuildVoice, GuildID: testGuildID}
+	}
+	tests := []struct {
+		name        string
+		before      *discordgo.Channel
+		after       *discordgo.Channel
+		wantLogged  bool
+		wantSubstrs []string
+	}{
+		{
+			name:        "rename logs before/after",
+			before:      voiceCh("VC1", "old-name"),
+			after:       voiceCh("VC1", "new-name"),
+			wantLogged:  true,
+			wantSubstrs: []string{"Voice Channel Renamed", "old-name", "new-name"},
+		},
+		{
+			name:       "uncached update is skipped (cannot confirm rename)",
+			before:     nil,
+			after:      voiceCh("VC1", "new-name"),
+			wantLogged: false,
+		},
+		{
+			name:       "no name change is skipped",
+			before:     voiceCh("VC1", "same"),
+			after:      voiceCh("VC1", "same"),
+			wantLogged: false,
+		},
+		{
+			name:       "text channel is skipped",
+			before:     &discordgo.Channel{ID: "C1", Name: "old", Type: discordgo.ChannelTypeGuildText, GuildID: testGuildID},
+			after:      &discordgo.Channel{ID: "C1", Name: "new", Type: discordgo.ChannelTypeGuildText, GuildID: testGuildID},
+			wantLogged: false,
+		},
+		{
+			name:       "DM is skipped",
+			before:     voiceCh("VC1", "old"),
+			after:      &discordgo.Channel{ID: "VC1", Name: "new", Type: discordgo.ChannelTypeGuildVoice},
+			wantLogged: false,
+		},
+		{
+			name:       "log channel itself is skipped",
+			before:     voiceCh(testLogChannelID, "old"),
+			after:      voiceCh(testLogChannelID, "new"),
+			wantLogged: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m, r := newTestModule(t)
+			s := newTestSession()
+			e := &discordgo.ChannelUpdate{Channel: tt.after, BeforeUpdate: tt.before}
+			m.OnChannelUpdate(s, e)
+			if got := len(r.logs) > 0; got != tt.wantLogged {
+				t.Fatalf("logged=%v want %v (logs=%d)", got, tt.wantLogged, len(r.logs))
+			}
+			if !tt.wantLogged {
+				return
+			}
+			assertPayloadWithinLimits(t, r.logs[0].payload)
+			for _, sub := range tt.wantSubstrs {
+				if !strings.Contains(r.logs[0].payload.content, sub) {
+					t.Errorf("missing %q in:\n%s", sub, r.logs[0].payload.content)
+				}
+			}
+		})
+	}
+}
+
+func TestOnChannelUpdate_NilEvent(t *testing.T) {
+	m, r := newTestModule(t)
+	s := newTestSession()
+	m.OnChannelUpdate(s, nil)
+	if len(r.logs) != 0 {
+		t.Fatalf("expected no log on nil, got %d", len(r.logs))
+	}
+}
+
+func TestOnRawEvent_VoiceChannelStatusUpdate(t *testing.T) {
+	tests := []struct {
+		name        string
+		eventType   string
+		rawData     string
+		wantLogged  bool
+		wantSubstrs []string
+	}{
+		{
+			name:        "status set logs new value",
+			eventType:   voiceChannelStatusUpdateRawType,
+			rawData:     `{"id":"VC1","guild_id":"G1","status":"playing minecraft"}`,
+			wantLogged:  true,
+			wantSubstrs: []string{"Voice Channel Status Updated", "VC1", "playing minecraft", "[voice]"},
+		},
+		{
+			name:        "empty status logs cleared",
+			eventType:   voiceChannelStatusUpdateRawType,
+			rawData:     `{"id":"VC1","guild_id":"G1","status":""}`,
+			wantLogged:  true,
+			wantSubstrs: []string{"(cleared)"},
+		},
+		{
+			name:       "missing guild_id is skipped",
+			eventType:  voiceChannelStatusUpdateRawType,
+			rawData:    `{"id":"VC1","status":"hi"}`,
+			wantLogged: false,
+		},
+		{
+			name:       "log channel itself is skipped",
+			eventType:  voiceChannelStatusUpdateRawType,
+			rawData:    `{"id":"` + testLogChannelID + `","guild_id":"G1","status":"hi"}`,
+			wantLogged: false,
+		},
+		{
+			name:       "non-status event types are ignored",
+			eventType:  "MESSAGE_CREATE",
+			rawData:    `{"id":"VC1","guild_id":"G1","status":"hi"}`,
+			wantLogged: false,
+		},
+		{
+			name:       "malformed JSON is ignored",
+			eventType:  voiceChannelStatusUpdateRawType,
+			rawData:    `{not json`,
+			wantLogged: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m, r := newTestModule(t)
+			s := newTestSession(voiceChannel("VC1", "general-voice"))
+			e := &discordgo.Event{Type: tt.eventType, RawData: []byte(tt.rawData)}
+			m.OnRawEvent(s, e)
+			if got := len(r.logs) > 0; got != tt.wantLogged {
+				t.Fatalf("logged=%v want %v (logs=%d)", got, tt.wantLogged, len(r.logs))
+			}
+			if !tt.wantLogged {
+				return
+			}
+			assertPayloadWithinLimits(t, r.logs[0].payload)
+			for _, sub := range tt.wantSubstrs {
+				if !strings.Contains(r.logs[0].payload.content, sub) {
+					t.Errorf("missing %q in:\n%s", sub, r.logs[0].payload.content)
+				}
+			}
+		})
+	}
+}
+
+func TestOnRawEvent_NilOrEmpty(t *testing.T) {
+	m, r := newTestModule(t)
+	s := newTestSession()
+	m.OnRawEvent(s, nil)
+	if len(r.logs) != 0 {
+		t.Fatalf("expected no log on nil event, got %d", len(r.logs))
+	}
+}
+
+func TestChannelTypeName(t *testing.T) {
+	tests := []struct {
+		name string
+		in   discordgo.ChannelType
+		want string
+	}{
+		{name: "voice", in: discordgo.ChannelTypeGuildVoice, want: "voice"},
+		{name: "stage voice", in: discordgo.ChannelTypeGuildStageVoice, want: "stage voice"},
+		{name: "text falls back to channel", in: discordgo.ChannelTypeGuildText, want: "channel"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := channelTypeName(tt.in); got != tt.want {
+				t.Errorf("got %q want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsVoiceLike(t *testing.T) {
+	tests := []struct {
+		name string
+		in   discordgo.ChannelType
+		want bool
+	}{
+		{name: "voice", in: discordgo.ChannelTypeGuildVoice, want: true},
+		{name: "stage", in: discordgo.ChannelTypeGuildStageVoice, want: true},
+		{name: "text", in: discordgo.ChannelTypeGuildText, want: false},
+		{name: "category", in: discordgo.ChannelTypeGuildCategory, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isVoiceLike(tt.in); got != tt.want {
+				t.Errorf("got %v want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUTF8TruncationDoesNotSplitRunes(t *testing.T) {
+	// Build a string whose byte boundary at inlineContentCap lands inside a
+	// multi-byte rune. 😀 is 4 bytes; pad with ASCII so the cut sits inside it.
+	tests := []struct {
+		name string
+		fn   func() string
+	}{
+		{
+			name: "codeBlock truncation respects rune boundaries",
+			fn: func() string {
+				body := strings.Repeat("a", inlineContentCap-1) + "😀😀😀"
+				return codeBlock(body)
+			},
+		},
+		{
+			name: "clampBytes truncation respects rune boundaries (with marker)",
+			fn: func() string {
+				body := strings.Repeat("a", maxAttachmentBytes-1) + "😀😀😀"
+				return string(clampBytes([]byte(body), maxAttachmentBytes))
+			},
+		},
+		{
+			name: "clampBytes truncation respects rune boundaries (under marker size)",
+			fn: func() string {
+				// max smaller than the marker; ASCII pad then a multi-byte rune.
+				body := strings.Repeat("a", 5) + "😀"
+				return string(clampBytes([]byte(body), 7))
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.fn()
+			if !utf8.ValidString(got) {
+				t.Errorf("output is not valid UTF-8")
+			}
+		})
+	}
+}
+
+func TestRenderUnifiedDiff(t *testing.T) {
+tests := []struct {
+name        string
+before      string
+after       string
+wantSubstrs []string
+wantEmpty   bool
+}{
+{
+name:        "single line change shows minus and plus",
+before:      "hello",
+after:       "world",
+wantSubstrs: []string{"-hello", "+world", "@@"},
+},
+{
+name:        "added line",
+before:      "a\n",
+after:       "a\nb\n",
+wantSubstrs: []string{"+b"},
+},
+{
+name:      "identical inputs produce empty diff",
+before:    "same",
+after:     "same",
+wantEmpty: true,
+},
+}
+for _, tt := range tests {
+t.Run(tt.name, func(t *testing.T) {
+got := renderUnifiedDiff(tt.before, tt.after)
+if tt.wantEmpty {
+if got != "" {
+t.Errorf("expected empty diff, got %q", got)
+}
+return
+}
+for _, sub := range tt.wantSubstrs {
+if !strings.Contains(got, sub) {
+t.Errorf("missing %q in diff:\n%s", sub, got)
+}
+}
+})
+}
+}
+
+func TestOnMessageUpdate_RendersDiffBlock(t *testing.T) {
+m, r := newTestModule(t)
+s := newTestSession(textChannel("C1", "general"))
+editTime := time.Now()
+m.OnMessageUpdate(s, &discordgo.MessageUpdate{
+Message: &discordgo.Message{
+ID: "M1", ChannelID: "C1", GuildID: testGuildID,
+Author: &fakeUser, Content: "new text", EditedTimestamp: &editTime,
+},
+BeforeUpdate: &discordgo.Message{Content: "old text", Author: &fakeUser},
+})
+if len(r.logs) != 1 {
+t.Fatalf("want 1 log got %d", len(r.logs))
+}
+p := r.logs[0].payload
+assertPayloadWithinLimits(t, p)
+if !strings.Contains(p.content, "```diff") {
+t.Errorf("expected ```diff fenced block, got:\n%s", p.content)
+}
+if !strings.Contains(p.content, "-old text") || !strings.Contains(p.content, "+new text") {
+t.Errorf("expected diff lines, got:\n%s", p.content)
+}
+}
+
+func TestOnMessageUpdate_LongDiffStaysWithinLimits(t *testing.T) {
+// Build large before/after that produce a diff well over inline limits.
+// Each line is ~80 chars; 200 lines ~= 16KB before, with every line
+// changed in after, producing ~32KB of diff hunk lines.
+var beforeBuf, afterBuf strings.Builder
+for i := 0; i < 200; i++ {
+beforeBuf.WriteString(strings.Repeat("a", 80))
+beforeBuf.WriteByte('\n')
+afterBuf.WriteString(strings.Repeat("b", 80))
+afterBuf.WriteByte('\n')
+}
+
+m, r := newTestModule(t)
+s := newTestSession(textChannel("C1", "general"))
+editTime := time.Now()
+m.OnMessageUpdate(s, &discordgo.MessageUpdate{
+Message: &discordgo.Message{
+ID: "M1", ChannelID: "C1", GuildID: testGuildID,
+Author: &fakeUser, Content: afterBuf.String(), EditedTimestamp: &editTime,
+},
+BeforeUpdate: &discordgo.Message{Content: beforeBuf.String(), Author: &fakeUser},
+})
+
+if len(r.logs) != 1 {
+t.Fatalf("want 1 log got %d", len(r.logs))
+}
+assertPayloadWithinLimits(t, r.logs[0].payload)
+}
+
+func TestCodeBlockLang(t *testing.T) {
+tests := []struct {
+name        string
+lang        string
+input       string
+wantPrefix  string
+wantContent string
+}{
+{name: "diff lang", lang: "diff", input: "-a\n+b", wantPrefix: "```diff\n"},
+{name: "no lang", lang: "", input: "x", wantPrefix: "```\n"},
+{name: "empty body diff", lang: "diff", input: "", wantContent: "```diff\n```"},
+}
+for _, tt := range tests {
+t.Run(tt.name, func(t *testing.T) {
+got := codeBlockLang(tt.lang, tt.input)
+if tt.wantContent != "" {
+if got != tt.wantContent {
+t.Errorf("got %q want %q", got, tt.wantContent)
+}
+return
+}
+if !strings.HasPrefix(got, tt.wantPrefix) {
+t.Errorf("missing prefix %q in:\n%s", tt.wantPrefix, got)
+}
+})
+}
+}

--- a/internal/commands/modules/nineteeneightyfour/nineteeneightyfour_test.go
+++ b/internal/commands/modules/nineteeneightyfour/nineteeneightyfour_test.go
@@ -360,17 +360,17 @@ func TestBuildPayload(t *testing.T) {
 			wantFirstFileName: "huge.txt",
 		},
 		{
-			name:             "too many large attachments are merged into combined.txt",
-			content:          "header",
-			attachments:      overflowAttachments,
-			wantFileCount:    maxAttachmentsPerMessage,
-			wantLastFileName: "combined.txt",
+			name:              "too many large attachments are dropped with note",
+			content:           "header",
+			attachments:       overflowAttachments,
+			wantFileCount:     maxAttachmentsPerMessage,
+			wantContentSubstr: "omitted due to Discord per-message limit",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p := buildPayload(tt.content, tt.attachments)
+			p := buildPayload(tt.content, tt.attachments, nil)
 			assertPayloadWithinLimits(t, p)
 
 			if tt.wantContentEquals != "" && p.content != tt.wantContentEquals {
@@ -433,7 +433,7 @@ func TestBuildPayloadStress(t *testing.T) {
 						content: strings.Repeat("a", aSize),
 					})
 				}
-				p := buildPayload(content, atts)
+				p := buildPayload(content, atts, nil)
 				assertPayloadWithinLimits(t, p)
 			}
 		}
@@ -1354,6 +1354,290 @@ return
 }
 if !strings.HasPrefix(got, tt.wantPrefix) {
 t.Errorf("missing prefix %q in:\n%s", tt.wantPrefix, got)
+}
+})
+}
+}
+
+// ---------------------------------------------------------------------------
+// Image attachment re-hosting
+// ---------------------------------------------------------------------------
+
+func TestIsImageAttachment(t *testing.T) {
+tests := []struct {
+name string
+att  *discordgo.MessageAttachment
+want bool
+}{
+{"image content type", &discordgo.MessageAttachment{ContentType: "image/png", Filename: "x"}, true},
+{"image content type uppercase", &discordgo.MessageAttachment{ContentType: "IMAGE/JPEG", Filename: "x"}, true},
+{"png by ext", &discordgo.MessageAttachment{Filename: "pic.PNG"}, true},
+{"jpg by ext", &discordgo.MessageAttachment{Filename: "pic.jpg"}, true},
+{"webp by ext", &discordgo.MessageAttachment{Filename: "pic.webp"}, true},
+{"gif by ext", &discordgo.MessageAttachment{Filename: "anim.gif"}, true},
+{"non-image text", &discordgo.MessageAttachment{ContentType: "text/plain", Filename: "notes.txt"}, false},
+{"non-image video", &discordgo.MessageAttachment{ContentType: "video/mp4", Filename: "clip.mp4"}, false},
+{"unknown ext", &discordgo.MessageAttachment{Filename: "data.bin"}, false},
+}
+for _, tt := range tests {
+t.Run(tt.name, func(t *testing.T) {
+if got := isImageAttachment(tt.att); got != tt.want {
+t.Errorf("isImageAttachment(%+v) = %v, want %v", tt.att, got, tt.want)
+}
+})
+}
+}
+
+func TestRehostImages(t *testing.T) {
+pngBytes := []byte("\x89PNG\r\n\x1a\nfakeimagedata")
+tests := []struct {
+name        string
+attachments []*discordgo.MessageAttachment
+fetcher     func(url string, max int) ([]byte, error)
+wantFiles   int
+wantNotes   int
+wantNoteSub string
+}{
+{
+name:        "no attachments",
+attachments: nil,
+wantFiles:   0,
+wantNotes:   0,
+},
+{
+name: "single image rehosted",
+attachments: []*discordgo.MessageAttachment{
+{Filename: "pic.png", ContentType: "image/png", URL: "https://x/pic.png", Size: 100},
+},
+fetcher:   func(_ string, _ int) ([]byte, error) { return pngBytes, nil },
+wantFiles: 1,
+wantNotes: 0,
+},
+{
+name: "non-image skipped silently",
+attachments: []*discordgo.MessageAttachment{
+{Filename: "doc.pdf", ContentType: "application/pdf", URL: "https://x/doc.pdf", Size: 100},
+},
+fetcher:   func(_ string, _ int) ([]byte, error) { return pngBytes, nil },
+wantFiles: 0,
+wantNotes: 0,
+},
+{
+name: "fetch failure produces note, no file",
+attachments: []*discordgo.MessageAttachment{
+{Filename: "pic.png", ContentType: "image/png", URL: "https://x/pic.png", Size: 100},
+},
+fetcher:     func(_ string, _ int) ([]byte, error) { return nil, errFetch },
+wantFiles:   0,
+wantNotes:   1,
+wantNoteSub: "not re-hosted",
+},
+{
+name: "oversized declared size produces note, fetcher not called",
+attachments: []*discordgo.MessageAttachment{
+{Filename: "huge.png", ContentType: "image/png", URL: "https://x/huge.png", Size: maxAttachmentBytes + 1},
+},
+fetcher: func(_ string, _ int) ([]byte, error) {
+t.Fatalf("fetcher should not be called for oversized attachment")
+return nil, nil
+},
+wantFiles:   0,
+wantNotes:   1,
+wantNoteSub: "exceeds",
+},
+{
+name: "mixed: image rehosted, text skipped, broken-image noted",
+attachments: []*discordgo.MessageAttachment{
+{Filename: "ok.png", ContentType: "image/png", URL: "https://x/ok.png", Size: 100},
+{Filename: "notes.txt", ContentType: "text/plain", URL: "https://x/notes.txt", Size: 100},
+{Filename: "broken.jpg", ContentType: "image/jpeg", URL: "https://x/broken.jpg", Size: 100},
+},
+fetcher: func(url string, _ int) ([]byte, error) {
+if strings.Contains(url, "broken") {
+return nil, errFetch
+}
+return pngBytes, nil
+},
+wantFiles: 1,
+wantNotes: 1,
+},
+{
+name: "nil entry tolerated",
+attachments: []*discordgo.MessageAttachment{
+nil,
+{Filename: "pic.png", ContentType: "image/png", URL: "https://x/pic.png", Size: 100},
+},
+fetcher:   func(_ string, _ int) ([]byte, error) { return pngBytes, nil },
+wantFiles: 1,
+wantNotes: 0,
+},
+}
+for _, tt := range tests {
+t.Run(tt.name, func(t *testing.T) {
+m, _ := newTestModule(t)
+if tt.fetcher != nil {
+m.fetchImage = tt.fetcher
+}
+files, notes := m.rehostImages(tt.attachments)
+if len(files) != tt.wantFiles {
+t.Errorf("files = %d, want %d", len(files), tt.wantFiles)
+}
+if len(notes) != tt.wantNotes {
+t.Errorf("notes = %d, want %d (notes=%v)", len(notes), tt.wantNotes, notes)
+}
+if tt.wantNoteSub != "" {
+found := false
+for _, n := range notes {
+if strings.Contains(n, tt.wantNoteSub) {
+found = true
+break
+}
+}
+if !found {
+t.Errorf("no note contained %q; notes=%v", tt.wantNoteSub, notes)
+}
+}
+for _, f := range files {
+if f.name == "" {
+t.Error("rehosted file has empty name")
+}
+if len(f.content) == 0 {
+t.Error("rehosted file has empty content")
+}
+}
+})
+}
+}
+
+var errFetch = fakeErr("fetch failed")
+
+type fakeErr string
+
+func (e fakeErr) Error() string { return string(e) }
+
+func TestOnMessageCreate_RehostsImages(t *testing.T) {
+m, r := newTestModule(t)
+pngBytes := []byte("\x89PNG\r\n\x1a\nfakeimagedata")
+m.fetchImage = func(url string, _ int) ([]byte, error) {
+return pngBytes, nil
+}
+s := newTestSession(textChannel("C1", "general"))
+
+m.OnMessageCreate(s, &discordgo.MessageCreate{Message: &discordgo.Message{
+ID: "M1", ChannelID: "C1", GuildID: testGuildID, Author: &fakeUser,
+Content: "hello",
+Attachments: []*discordgo.MessageAttachment{
+{Filename: "pic.png", ContentType: "image/png", URL: "https://x/pic.png", Size: 100},
+},
+}})
+
+if len(r.logs) != 1 {
+t.Fatalf("logs = %d, want 1", len(r.logs))
+}
+p := r.logs[0].payload
+assertPayloadWithinLimits(t, p)
+if len(p.files) != 1 {
+t.Fatalf("files = %d, want 1", len(p.files))
+}
+if p.files[0].name != "pic.png" {
+t.Errorf("file name = %q, want pic.png", p.files[0].name)
+}
+if string(p.files[0].content) != string(pngBytes) {
+t.Errorf("file content not preserved")
+}
+}
+
+func TestOnMessageCreate_SkipsNonImageAttachments(t *testing.T) {
+m, r := newTestModule(t)
+called := 0
+m.fetchImage = func(_ string, _ int) ([]byte, error) {
+called++
+return []byte("data"), nil
+}
+s := newTestSession(textChannel("C1", "general"))
+
+m.OnMessageCreate(s, &discordgo.MessageCreate{Message: &discordgo.Message{
+ID: "M1", ChannelID: "C1", GuildID: testGuildID, Author: &fakeUser,
+Content: "hello",
+Attachments: []*discordgo.MessageAttachment{
+{Filename: "doc.pdf", ContentType: "application/pdf", URL: "https://x/doc.pdf", Size: 100},
+{Filename: "clip.mp4", ContentType: "video/mp4", URL: "https://x/clip.mp4", Size: 100},
+},
+}})
+
+if called != 0 {
+t.Errorf("fetcher called %d times for non-image attachments, want 0", called)
+}
+if len(r.logs) != 1 {
+t.Fatalf("logs = %d, want 1", len(r.logs))
+}
+if len(r.logs[0].payload.files) != 0 {
+t.Errorf("files = %d, want 0", len(r.logs[0].payload.files))
+}
+}
+
+func TestOnMessageCreate_FetchFailureStillLogs(t *testing.T) {
+m, r := newTestModule(t)
+m.fetchImage = func(_ string, _ int) ([]byte, error) {
+return nil, errFetch
+}
+s := newTestSession(textChannel("C1", "general"))
+
+m.OnMessageCreate(s, &discordgo.MessageCreate{Message: &discordgo.Message{
+ID: "M1", ChannelID: "C1", GuildID: testGuildID, Author: &fakeUser,
+Content: "hi",
+Attachments: []*discordgo.MessageAttachment{
+{Filename: "pic.png", ContentType: "image/png", URL: "https://x/pic.png", Size: 100},
+},
+}})
+
+if len(r.logs) != 1 {
+t.Fatalf("logs = %d, want 1", len(r.logs))
+}
+if !strings.Contains(r.logs[0].payload.content, "not re-hosted") {
+t.Errorf("expected failure note in content, got: %q", r.logs[0].payload.content)
+}
+if len(r.logs[0].payload.files) != 0 {
+t.Errorf("files = %d, want 0 on fetch failure", len(r.logs[0].payload.files))
+}
+}
+
+func TestBuildPayload_ExtraFilesPriority(t *testing.T) {
+// With 11 binary files plus content > inline cap (which would normally
+// add a log.txt), we should drop overflow and note it. Binary files
+// should keep their slots; the long content text fallback is the one
+// that gets dropped.
+bins := make([]fileSpec, maxAttachmentsPerMessage+1)
+for i := range bins {
+bins[i] = fileSpec{name: "img.png", content: []byte("img")}
+}
+p := buildPayload("short", nil, bins)
+assertPayloadWithinLimits(t, p)
+if len(p.files) != maxAttachmentsPerMessage {
+t.Fatalf("files = %d, want %d", len(p.files), maxAttachmentsPerMessage)
+}
+if !strings.Contains(p.content, "omitted") {
+t.Errorf("expected omitted note in content, got: %q", p.content)
+}
+}
+
+func TestDetectContentType(t *testing.T) {
+tests := []struct {
+name     string
+fname    string
+data     []byte
+wantSub  string
+}{
+{"txt", "log.txt", []byte("hello"), "text/plain"},
+{"patch", "diff.patch", []byte("--- a"), "text/plain"},
+{"png", "pic.png", []byte("\x89PNG\r\n\x1a\n"), "image/png"},
+{"empty", "x.bin", nil, "application/octet-stream"},
+}
+for _, tt := range tests {
+t.Run(tt.name, func(t *testing.T) {
+got := detectContentType(tt.fname, tt.data)
+if !strings.Contains(got, tt.wantSub) {
+t.Errorf("detectContentType(%q) = %q, want substr %q", tt.fname, got, tt.wantSub)
 }
 })
 }

--- a/internal/config/config_accessors.go
+++ b/internal/config/config_accessors.go
@@ -58,6 +58,12 @@ func (c *Config) GetGamerPalsVoiceSyncCategoryID() string {
 	return c.v.GetString("gamerpals_voice_sync_category_id")
 }
 
+// GetGamerPals1984LogChannelID returns the channel ID where the 1984 module
+// posts message activity logs (creates, edits, deletes, reactions).
+func (c *Config) GetGamerPals1984LogChannelID() string {
+	return c.v.GetString("gamerpals_1984_log_channel_id")
+}
+
 // LFG Looking NOW panel channel ID (persisted so panel survives restarts)
 func (c *Config) GetLFGNowPanelChannelID() string {
 	return c.v.GetString("gamerpals_lfg_now_panel_channel_id")


### PR DESCRIPTION
Adds a new `1984` module that logs every message activity and voice-channel event across all visible channels to a single configured audit channel.

## What's logged

- Message create / edit / delete (with diff for edits)
- Reaction add / remove
- Voice channel create / rename
- Voice channel status updates (via raw gateway event, since discordgo doesn't model this typed)

Edits render as a unified diff inside a ` ```diff ` fenced block. Full before/after/diff are also attached as files for completeness.

## Discord API safety

A single `buildPayload` chokepoint enforces:

- content length (1900 chars)
- attachment count (10)
- per-file size (8 MB)

Overflow is automatically offloaded to text attachments. Truncation is UTF-8 rune-aware so multi-byte runes (emoji / CJK) are never split.

## Edge cases handled

- `MESSAGE_UPDATE` is a partial payload: requires `EditedTimestamp != nil` and falls back to `BeforeUpdate.Author` when the payload omits it (avoids false "content cleared" entries from embed unfurls).
- `CHANNEL_UPDATE` is also partial: requires a cached `BeforeUpdate` to confirm an actual rename before logging.
- Sticker / poll / component-only message creates are not silently dropped.
- Skips the log channel itself, DMs, and the bot's own messages.

## Configuration

New config key: `gamerpals_1984_log_channel_id` (accessor + example yaml + `/config list-keys` entry).

Module is wired in `bot.go` with `session.State.MaxMessageCount = 500` so discordgo populates `BeforeUpdate` / `BeforeDelete` from cache.

## Testing

Table-driven tests at ~94% coverage including:

- combinatorial sweep over content/attachment shapes
- long-diff stress case asserting payload stays within Discord limits
- UTF-8 boundary truncation tests
- partial-payload scenarios for `MESSAGE_UPDATE` and `CHANNEL_UPDATE`

Local `go build`, `go vet`, `go test ./...` all pass.
