### PR TITLE
ci: read AZURE_TENANT_ID and AZURE_SUBSCRIPTION_ID from secrets

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -53,8 +53,8 @@ jobs:
           image-tag: dev
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || '' }}
           azure-client-id: ${{ vars.AZURE_CLIENT_ID }}
-          azure-tenant-id: ${{ vars.AZURE_TENANT_ID }}
-          azure-subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           aca-resource-group: ${{ vars.ACA_RESOURCE_GROUP }}
           aca-app-name: ${{ vars.ACA_APP_NAME }}
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,8 +48,8 @@ jobs:
         with:
           image-tag: prod
           azure-client-id: ${{ vars.AZURE_CLIENT_ID }}
-          azure-tenant-id: ${{ vars.AZURE_TENANT_ID }}
-          azure-subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           aca-resource-group: ${{ vars.ACA_RESOURCE_GROUP }}
           aca-app-name: ${{ vars.ACA_APP_NAME }}
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Tenant ID and Subscription ID are not credentials (auth is gated by the federated OIDC subject scope), but GitHub Actions echoes variables in workflow logs by default. Move them to environment secrets so they're masked in run logs.

`AZURE_CLIENT_ID` stays as a variable since it's fundamentally a public identifier in the OIDC exchange. Operational identifiers (`ACA_RESOURCE_GROUP`, `ACA_APP_NAME`) also stay as variables.

Env-side change already applied in both `dev` and `production` environments (vars deleted, secrets created with identical values).