### PR TITLE
Add separate intro feed rate limit for server boosters

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -11,6 +11,7 @@
 #   bot_token                              -> GAMERPAL_BOT_TOKEN
 #   gamerpals_server_id                    -> GAMERPAL_GAMERPALS_SERVER_ID
 #   intro_feed_rate_limit_hours            -> GAMERPAL_INTRO_FEED_RATE_LIMIT_HOURS
+#   intro_feed_booster_rate_limit_hours    -> GAMERPAL_INTRO_FEED_BOOSTER_RATE_LIMIT_HOURS
 #   disable_file_logging                   -> GAMERPAL_DISABLE_FILE_LOGGING
 #
 # Environment variables take precedence over values in config.yaml. This is
@@ -118,6 +119,11 @@ intro_feed_channel_id: "your-intro-feed-channel-id-here"
 
 # Hours between allowed feed posts per user (prevents spam from delete+repost).
 intro_feed_rate_limit_hours: 48
+
+# Separate rate limit (hours) for server (Nitro) boosters. Leave at 0 / unset to
+# have boosters use the standard intro_feed_rate_limit_hours above. Booster status
+# is read from the Discord API (premium_since).
+intro_feed_booster_rate_limit_hours: 0
 
 # ----------------------------------------------------------------------------
 # New Pals system

--- a/internal/commands/modules/config/config.go
+++ b/internal/commands/modules/config/config.go
@@ -165,6 +165,7 @@ func (m *ConfigModule) handleConfigListKeys(s *discordgo.Session, i *discordgo.I
 		{"gamerpals_1984_log_channel_id", true},            // Harmless ID
 		{"intro_feed_channel_id", true},                    // Harmless ID
 		{"intro_feed_rate_limit_hours", true},              // Duration setting
+		{"intro_feed_booster_rate_limit_hours", true},      // Duration setting
 		{"event_feed_channel_id", true},                    // Harmless ID
 		{"new_pals_system_enabled", true},                  // Boolean setting
 		{"new_pals_role_id", true},                         // Harmless ID

--- a/internal/commands/modules/intro/service.go
+++ b/internal/commands/modules/intro/service.go
@@ -34,8 +34,9 @@ type EligibilityResult struct {
 }
 
 // CheckFeedEligibility checks if a user is eligible to have their intro posted to the feed.
-// This checks the database for the last time they had an intro posted.
-func (s *IntroFeedService) CheckFeedEligibility(userID string) (*EligibilityResult, error) {
+// This checks the database for the last time they had an intro posted. Server (Nitro) boosters
+// use a separate rate limit when one is configured (see feedCooldownHours).
+func (s *IntroFeedService) CheckFeedEligibility(guildID, userID string) (*EligibilityResult, error) {
 	if s.deps.DB == nil {
 		return &EligibilityResult{
 			Eligible: false,
@@ -43,7 +44,7 @@ func (s *IntroFeedService) CheckFeedEligibility(userID string) (*EligibilityResu
 		}, nil
 	}
 
-	cooldownHours := s.deps.Config.GetIntroFeedRateLimitHours()
+	cooldownHours := s.feedCooldownHours(guildID, userID)
 	eligible, remaining, err := s.deps.DB.IsUserEligibleForIntroFeed(userID, cooldownHours)
 	if err != nil {
 		return nil, fmt.Errorf("failed to check feed eligibility: %w", err)
@@ -60,6 +61,40 @@ func (s *IntroFeedService) CheckFeedEligibility(userID string) (*EligibilityResu
 	return &EligibilityResult{
 		Eligible: true,
 	}, nil
+}
+
+// feedCooldownHours returns the rate-limit window (in hours) that applies to a user. When a
+// booster rate limit is configured and the user is a server booster, the booster window is used;
+// otherwise the standard window applies. The member is only fetched when a booster limit is set.
+func (s *IntroFeedService) feedCooldownHours(guildID, userID string) int {
+	boosterHours := s.deps.Config.GetIntroFeedBoosterRateLimitHours()
+	if boosterHours <= 0 || s.deps.Session == nil {
+		return s.deps.Config.GetIntroFeedRateLimitHours()
+	}
+
+	member, err := s.deps.Session.GuildMember(guildID, userID)
+	if err != nil {
+		s.deps.Config.Logger.Warnf("Failed to fetch member %s for booster rate limit check: %v", userID, err)
+		return s.deps.Config.GetIntroFeedRateLimitHours()
+	}
+
+	return s.cooldownHoursForMember(member)
+}
+
+// cooldownHoursForMember returns the applicable feed cooldown for an already-resolved member,
+// preferring the booster rate limit when configured and the member is a server booster.
+func (s *IntroFeedService) cooldownHoursForMember(member *discordgo.Member) int {
+	boosterHours := s.deps.Config.GetIntroFeedBoosterRateLimitHours()
+	if boosterHours > 0 && s.memberIsBooster(member) {
+		return boosterHours
+	}
+	return s.deps.Config.GetIntroFeedRateLimitHours()
+}
+
+// memberIsBooster reports whether a guild member is a server (Nitro) booster, as reported by the
+// Discord API's premium_since field.
+func (s *IntroFeedService) memberIsBooster(member *discordgo.Member) bool {
+	return member != nil && member.PremiumSince != nil
 }
 
 // ForwardThreadToFeed posts a notification about a new/bumped intro thread to the feed channel.
@@ -185,7 +220,7 @@ func (s *IntroFeedService) HandleNewIntroThread(thread *discordgo.Channel) {
 	}
 
 	// Check eligibility (silently skip if on cooldown)
-	eligibility, err := s.CheckFeedEligibility(thread.OwnerID)
+	eligibility, err := s.CheckFeedEligibility(thread.GuildID, thread.OwnerID)
 	if err != nil {
 		s.deps.Config.Logger.Warnf("Failed to check intro feed eligibility for user %s: %v", thread.OwnerID, err)
 		return
@@ -227,7 +262,7 @@ func (s *IntroFeedService) HandleNewIntroThread(thread *discordgo.Channel) {
 func (s *IntroFeedService) BumpIntroToFeed(guildID, threadID, userID, displayName, threadName string, skipEligibilityCheck bool) error {
 	// Check eligibility unless bypassed
 	if !skipEligibilityCheck {
-		eligibility, err := s.CheckFeedEligibility(userID)
+		eligibility, err := s.CheckFeedEligibility(guildID, userID)
 		if err != nil {
 			return fmt.Errorf("failed to check eligibility: %w", err)
 		}

--- a/internal/commands/modules/intro/service_test.go
+++ b/internal/commands/modules/intro/service_test.go
@@ -1,0 +1,67 @@
+package intro
+
+import (
+	"testing"
+	"time"
+
+	"gamerpal/internal/commands/types"
+	"gamerpal/internal/config"
+
+	"github.com/bwmarrin/discordgo"
+	"github.com/stretchr/testify/assert"
+)
+
+func newFeedService(kv map[string]interface{}) *IntroFeedService {
+	return &IntroFeedService{deps: &types.Dependencies{Config: config.NewMockConfig(kv)}}
+}
+
+func TestMemberIsBooster(t *testing.T) {
+	now := time.Now()
+
+	tests := []struct {
+		name   string
+		member *discordgo.Member
+		want   bool
+	}{
+		{name: "nil member", member: nil, want: false},
+		{name: "premium_since set (api truth)", member: &discordgo.Member{PremiumSince: &now}, want: true},
+		{name: "no premium_since", member: &discordgo.Member{Roles: []string{"x"}}, want: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			svc := newFeedService(map[string]interface{}{})
+			assert.Equal(t, tc.want, svc.memberIsBooster(tc.member))
+		})
+	}
+}
+
+func TestCooldownHoursForMember(t *testing.T) {
+	now := time.Now()
+
+	t.Run("booster limit unset -> standard window even for booster", func(t *testing.T) {
+		svc := newFeedService(map[string]interface{}{"intro_feed_rate_limit_hours": 48})
+		assert.Equal(t, 48, svc.cooldownHoursForMember(&discordgo.Member{PremiumSince: &now}))
+	})
+
+	t.Run("booster limit set -> booster window for booster", func(t *testing.T) {
+		svc := newFeedService(map[string]interface{}{
+			"intro_feed_rate_limit_hours":         48,
+			"intro_feed_booster_rate_limit_hours": 12,
+		})
+		assert.Equal(t, 12, svc.cooldownHoursForMember(&discordgo.Member{PremiumSince: &now}))
+	})
+
+	t.Run("booster limit set -> standard window for non-booster", func(t *testing.T) {
+		svc := newFeedService(map[string]interface{}{
+			"intro_feed_rate_limit_hours":         48,
+			"intro_feed_booster_rate_limit_hours": 12,
+		})
+		assert.Equal(t, 48, svc.cooldownHoursForMember(&discordgo.Member{Roles: []string{"x"}}))
+	})
+
+	t.Run("standard default (48) applies when standard limit unset", func(t *testing.T) {
+		svc := newFeedService(map[string]interface{}{"intro_feed_booster_rate_limit_hours": 6})
+		assert.Equal(t, 48, svc.cooldownHoursForMember(&discordgo.Member{}))
+	})
+}

--- a/internal/config/config_accessors.go
+++ b/internal/config/config_accessors.go
@@ -241,6 +241,13 @@ func (c *Config) GetIntroFeedRateLimitHours() int {
 	return hours
 }
 
+// GetIntroFeedBoosterRateLimitHours returns the number of hours between allowed feed posts for
+// server (Nitro) boosters. A value <= 0 means it is not configured, in which case boosters use
+// the standard rate limit (GetIntroFeedRateLimitHours).
+func (c *Config) GetIntroFeedBoosterRateLimitHours() int {
+	return c.v.GetInt("intro_feed_booster_rate_limit_hours")
+}
+
 // Translate language configuration
 // -----
 


### PR DESCRIPTION
Adds an optional, separate intro feed cooldown for server (Nitro) boosters via a new `intro_feed_booster_rate_limit_hours` config key.

- Boost status is read from the Discord API (`premium_since`).
- When the key is unset (`<= 0`), boosters use the standard `intro_feed_rate_limit_hours`, so the feature is off by default.
- The member is only fetched when a booster limit is configured; on fetch failure it falls back to the standard limit.

Surfaced in `/config list-keys` and documented in `config.example.yaml`. Unit tests cover booster detection and cooldown selection.