### PR TITLE
Fix Connect 4 reaction reliability and data race

### DIFF
--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -150,6 +150,9 @@ func New(cfg *config.Config) (*Bot, error) {
 	session.AddHandler(func(s *discordgo.Session, r *discordgo.MessageReactionAdd) {
 		handler.HandleReactionAdd(s, r)
 	})
+	session.AddHandler(func(s *discordgo.Session, r *discordgo.MessageReactionRemove) {
+		handler.HandleReactionRemove(s, r)
+	})
 
 	return bot, nil
 }

--- a/internal/commands/module_handler.go
+++ b/internal/commands/module_handler.go
@@ -244,6 +244,15 @@ func (h *ModuleHandler) HandleReactionAdd(s *discordgo.Session, r *discordgo.Mes
 	}
 }
 
+// HandleReactionRemove routes message reaction removal events to modules that
+// use them. Connect 4 treats a removed reaction as input too, so a tap that
+// toggles a lingering reaction off still registers as a move.
+func (h *ModuleHandler) HandleReactionRemove(s *discordgo.Session, r *discordgo.MessageReactionRemove) {
+	if fun.IsConnect4Message(r.MessageID) {
+		fun.HandleReactionRemove(s, r)
+	}
+}
+
 // UnregisterCommands removes all registered commands
 func (h *ModuleHandler) UnregisterCommands(s *discordgo.Session) {
 	existingCommands, err := s.ApplicationCommands(s.State.User.ID, "")

--- a/internal/commands/modules/fun/connect4.go
+++ b/internal/commands/modules/fun/connect4.go
@@ -81,6 +81,11 @@ type connect4Manager struct {
 	once            sync.Once
 }
 
+type c4ExpiredGame struct {
+	game     *Connect4Game
+	accepted bool
+}
+
 var c4mgr = &connect4Manager{
 	games:           make(map[string]*Connect4Game),
 	msgToGame:       make(map[string]string),
@@ -140,23 +145,24 @@ func (mgr *connect4Manager) cleanupLoop() {
 	defer ticker.Stop()
 
 	for range ticker.C {
-		expired := mgr.collectExpired()
-		for _, game := range expired {
-			mgr.updateGameMessage(game)
-			if game.Accepted {
-				c4ClearReactions(mgr.session, game)
+		expired, session := mgr.collectExpired()
+		for _, e := range expired {
+			mgr.updateGameMessage(e.game)
+			if e.accepted {
+				c4ClearReactions(session, e.game)
 			}
 		}
 		mgr.removeStale()
 	}
 }
 
-func (mgr *connect4Manager) collectExpired() []*Connect4Game {
+func (mgr *connect4Manager) collectExpired() ([]c4ExpiredGame, *discordgo.Session) {
 	mgr.mu.Lock()
 	defer mgr.mu.Unlock()
 
-	var expired []*Connect4Game
+	var expired []c4ExpiredGame
 	now := time.Now()
+	session := mgr.session
 
 	for _, game := range mgr.games {
 		if game.Status == c4Finished || now.Sub(game.LastActivity) <= c4Timeout {
@@ -177,9 +183,12 @@ func (mgr *connect4Manager) collectExpired() []*Connect4Game {
 				game.WinReason = fmt.Sprintf("⏰ <@%s> took too long - %s <@%s> wins!", game.Player2, c4EmojiPlayer1, game.Player1)
 			}
 		}
-		expired = append(expired, game)
+		expired = append(expired, c4ExpiredGame{
+			game:     game,
+			accepted: game.Accepted,
+		})
 	}
-	return expired
+	return expired, session
 }
 
 func (mgr *connect4Manager) removeStale() {
@@ -626,10 +635,6 @@ func HandleReactionAdd(s *discordgo.Session, r *discordgo.MessageReactionAdd) {
 	// and not replayed as a phantom move (see HandleReactionRemove).
 	defer c4mgr.cleanupUserReaction(s, r.ChannelID, r.MessageID, r.UserID, r.Emoji.APIName())
 
-	if game.Status != c4Active {
-		return
-	}
-
 	c4RouteReactionIntent(s, game, r.UserID, r.Emoji.Name)
 }
 
@@ -650,10 +655,6 @@ func HandleReactionRemove(s *discordgo.Session, r *discordgo.MessageReactionRemo
 
 	// Swallow the removal the bot itself issued while cleaning up after a move.
 	if c4mgr.consumeSelfRemoval(r.MessageID, r.UserID, r.Emoji.APIName()) {
-		return
-	}
-
-	if game.Status != c4Active {
 		return
 	}
 

--- a/internal/commands/modules/fun/connect4.go
+++ b/internal/commands/modules/fun/connect4.go
@@ -28,6 +28,7 @@ const (
 	c4EmojiEmpty   = "⚫"
 	c4EmojiPlayer1 = "🔴"
 	c4EmojiPlayer2 = "🟡"
+	c4EmojiForfeit = "🏳️"
 
 	c4ColorRed    = 0xE74C3C
 	c4ColorYellow = 0xF1C40F
@@ -36,7 +37,7 @@ const (
 	c4ColorBlue   = 0x3498DB
 )
 
-// Column reaction emoji — users react with these to pick a column.
+// Column reaction emoji - users react with these to pick a column.
 var c4ColumnEmoji = []string{"1️⃣", "2️⃣", "3️⃣", "4️⃣", "5️⃣", "6️⃣", "7️⃣"}
 
 type c4Status int
@@ -60,6 +61,8 @@ type Connect4Game struct {
 	Status       c4Status
 	Winner       int // 0 = draw, c4Player1 or c4Player2
 	WinReason    string
+	Moves        int  // pieces dropped so far; used to decide whether to render the board
+	Accepted     bool // true once the challenge is accepted and play reactions are added
 	LastActivity time.Time
 }
 
@@ -68,15 +71,20 @@ type Connect4Game struct {
 type connect4Manager struct {
 	games     map[string]*Connect4Game
 	msgToGame map[string]string // messageID → gameID for fast reaction lookup
-	mu        sync.Mutex
-	session   *discordgo.Session
-	cfg       *config.Config
-	once      sync.Once
+	// pendingRemovals counts reaction removals the bot initiated itself (while
+	// cleaning up after a move). Keyed by messageID|userID|emoji so the matching
+	// gateway remove event can be swallowed instead of replayed as a move.
+	pendingRemovals map[string]int
+	mu              sync.Mutex
+	session         *discordgo.Session
+	cfg             *config.Config
+	once            sync.Once
 }
 
 var c4mgr = &connect4Manager{
-	games:     make(map[string]*Connect4Game),
-	msgToGame: make(map[string]string),
+	games:           make(map[string]*Connect4Game),
+	msgToGame:       make(map[string]string),
+	pendingRemovals: make(map[string]int),
 }
 
 func (mgr *connect4Manager) init(s *discordgo.Session, cfg *config.Config) {
@@ -135,6 +143,9 @@ func (mgr *connect4Manager) cleanupLoop() {
 		expired := mgr.collectExpired()
 		for _, game := range expired {
 			mgr.updateGameMessage(game)
+			if game.Accepted {
+				c4ClearReactions(mgr.session, game)
+			}
 		}
 		mgr.removeStale()
 	}
@@ -160,10 +171,10 @@ func (mgr *connect4Manager) collectExpired() []*Connect4Game {
 		} else {
 			if game.Turn == c4Player1 {
 				game.Winner = c4Player2
-				game.WinReason = fmt.Sprintf("⏰ <@%s> took too long — %s <@%s> wins!", game.Player1, c4EmojiPlayer2, game.Player2)
+				game.WinReason = fmt.Sprintf("⏰ <@%s> took too long - %s <@%s> wins!", game.Player1, c4EmojiPlayer2, game.Player2)
 			} else {
 				game.Winner = c4Player1
-				game.WinReason = fmt.Sprintf("⏰ <@%s> took too long — %s <@%s> wins!", game.Player2, c4EmojiPlayer1, game.Player1)
+				game.WinReason = fmt.Sprintf("⏰ <@%s> took too long - %s <@%s> wins!", game.Player2, c4EmojiPlayer1, game.Player1)
 			}
 		}
 		expired = append(expired, game)
@@ -178,22 +189,102 @@ func (mgr *connect4Manager) removeStale() {
 	now := time.Now()
 	for id, game := range mgr.games {
 		if game.Status == c4Finished && now.Sub(game.LastActivity) > 5*time.Minute {
+			mgr.purgePendingRemovalsLocked(game.MessageID)
 			delete(mgr.msgToGame, game.MessageID)
 			delete(mgr.games, id)
 		}
 	}
 }
 
+// --- Self-removal bookkeeping ---
+//
+// The bot removes a player's reaction after each move to keep the row tidy.
+// That removal fires a gateway remove event indistinguishable from a player
+// toggling their own reaction off. We record each bot-initiated removal so the
+// remove handler can swallow exactly that event and still treat genuine player
+// toggles as moves.
+
+func c4RemovalKey(messageID, userID, emojiAPIName string) string {
+	return messageID + "|" + userID + "|" + c4NormalizeEmoji(emojiAPIName)
+}
+
+func (mgr *connect4Manager) markSelfRemoval(messageID, userID, emojiAPIName string) {
+	key := c4RemovalKey(messageID, userID, emojiAPIName)
+	mgr.mu.Lock()
+	mgr.pendingRemovals[key]++
+	mgr.mu.Unlock()
+}
+
+func (mgr *connect4Manager) unmarkSelfRemoval(messageID, userID, emojiAPIName string) {
+	key := c4RemovalKey(messageID, userID, emojiAPIName)
+	mgr.mu.Lock()
+	mgr.decPendingLocked(key)
+	mgr.mu.Unlock()
+}
+
+// consumeSelfRemoval reports whether the given removal was one the bot itself
+// performed, decrementing the pending count when so.
+func (mgr *connect4Manager) consumeSelfRemoval(messageID, userID, emojiAPIName string) bool {
+	key := c4RemovalKey(messageID, userID, emojiAPIName)
+	mgr.mu.Lock()
+	defer mgr.mu.Unlock()
+	if mgr.pendingRemovals[key] > 0 {
+		mgr.decPendingLocked(key)
+		return true
+	}
+	return false
+}
+
+func (mgr *connect4Manager) decPendingLocked(key string) {
+	if mgr.pendingRemovals[key] > 0 {
+		mgr.pendingRemovals[key]--
+		if mgr.pendingRemovals[key] == 0 {
+			delete(mgr.pendingRemovals, key)
+		}
+	}
+}
+
+// purgePendingRemovalsLocked drops any outstanding self-removal tokens for a
+// message. Callers must hold mgr.mu.
+func (mgr *connect4Manager) purgePendingRemovalsLocked(messageID string) {
+	prefix := messageID + "|"
+	for key := range mgr.pendingRemovals {
+		if strings.HasPrefix(key, prefix) {
+			delete(mgr.pendingRemovals, key)
+		}
+	}
+}
+
+// cleanupUserReaction removes a player's reaction to keep the row tidy, marking
+// the removal first so its gateway event isn't replayed as a move. If the API
+// call fails (commonly missing Manage Messages) no event will arrive, so the
+// token is dropped to avoid swallowing the player's next genuine toggle.
+func (mgr *connect4Manager) cleanupUserReaction(s *discordgo.Session, channelID, messageID, userID, emojiAPIName string) {
+	mgr.markSelfRemoval(messageID, userID, emojiAPIName)
+	if err := s.MessageReactionRemove(channelID, messageID, emojiAPIName, userID); err != nil {
+		mgr.unmarkSelfRemoval(messageID, userID, emojiAPIName)
+	}
+}
+
 // updateGameMessage edits the game's Discord message with the current state.
+// The embed and components are built while holding the lock so the rendered
+// board can't tear against a concurrent move; the network call runs unlocked.
 func (mgr *connect4Manager) updateGameMessage(game *Connect4Game) {
+	mgr.mu.Lock()
 	if mgr.session == nil || game.MessageID == "" {
+		mgr.mu.Unlock()
 		return
 	}
+	session := mgr.session
+	channelID := game.ChannelID
+	messageID := game.MessageID
 	embed := c4BuildGameEmbed(game)
 	components := c4BuildComponents(game)
-	_, _ = mgr.session.ChannelMessageEditComplex(&discordgo.MessageEdit{
-		Channel:    game.ChannelID,
-		ID:         game.MessageID,
+	mgr.mu.Unlock()
+
+	_, _ = session.ChannelMessageEditComplex(&discordgo.MessageEdit{
+		Channel:    channelID,
+		ID:         messageID,
 		Embeds:     &[]*discordgo.MessageEmbed{embed},
 		Components: &components,
 	})
@@ -297,8 +388,12 @@ func c4BuildGameEmbed(game *Connect4Game) *discordgo.MessageEmbed {
 		embed.Title = "🎮 Connect 4"
 		embed.Footer.Text = fmt.Sprintf("Game %s • Game over", game.ID)
 		desc.WriteString(fmt.Sprintf("%s <@%s>  vs  %s <@%s>\n\n", c4EmojiPlayer1, game.Player1, c4EmojiPlayer2, game.Player2))
-		desc.WriteString(c4RenderBoard(game))
-		desc.WriteString("\n")
+		// Only show the board if at least one piece was played; declined,
+		// cancelled, and pre-start timeouts shouldn't render an empty grid.
+		if game.Moves > 0 {
+			desc.WriteString(c4RenderBoard(game))
+			desc.WriteString("\n")
+		}
 		if game.WinReason != "" {
 			desc.WriteString(game.WinReason)
 		} else if game.Winner == c4Player1 {
@@ -350,7 +445,7 @@ func c4AddReactions(s *discordgo.Session, channelID, messageID string) {
 	for _, emoji := range c4ColumnEmoji {
 		_ = s.MessageReactionAdd(channelID, messageID, emoji)
 	}
-	_ = s.MessageReactionAdd(channelID, messageID, "🏳️")
+	_ = s.MessageReactionAdd(channelID, messageID, c4EmojiForfeit)
 }
 
 // --- Slash Command Handler ---
@@ -446,10 +541,10 @@ func (m *Module) handleC4Accept(s *discordgo.Session, i *discordgo.InteractionCr
 		return
 	}
 	game.Status = c4Active
+	game.Accepted = true
 	game.LastActivity = time.Now()
-	c4mgr.mu.Unlock()
-
 	embed := c4BuildGameEmbed(game)
+	c4mgr.mu.Unlock()
 
 	_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 		Type: discordgo.InteractionResponseUpdateMessage,
@@ -490,9 +585,8 @@ func (m *Module) handleC4Decline(s *discordgo.Session, i *discordgo.InteractionC
 	} else {
 		game.WinReason = fmt.Sprintf("❌ <@%s> declined the challenge.", game.Player2)
 	}
-	c4mgr.mu.Unlock()
-
 	embed := c4BuildGameEmbed(game)
+	c4mgr.mu.Unlock()
 
 	_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 		Type: discordgo.InteractionResponseUpdateMessage,
@@ -514,7 +608,7 @@ func IsConnect4Message(messageID string) bool {
 	return ok
 }
 
-// HandleReactionAdd processes a reaction on a Connect 4 game message.
+// HandleReactionAdd processes a reaction added on a Connect 4 game message.
 // Called from the bot's reaction event handler.
 func HandleReactionAdd(s *discordgo.Session, r *discordgo.MessageReactionAdd) {
 	// Ignore bot's own reactions
@@ -527,43 +621,69 @@ func HandleReactionAdd(s *discordgo.Session, r *discordgo.MessageReactionAdd) {
 		return
 	}
 
-	// Always remove the user's reaction to keep the board clean
-	defer func() {
-		_ = s.MessageReactionRemove(r.ChannelID, r.MessageID, r.Emoji.APIName(), r.UserID)
-	}()
+	// Keep the board clean by removing the user's reaction once handled. Record
+	// the removal first so the resulting gateway event is recognized as our own
+	// and not replayed as a phantom move (see HandleReactionRemove).
+	defer c4mgr.cleanupUserReaction(s, r.ChannelID, r.MessageID, r.UserID, r.Emoji.APIName())
 
 	if game.Status != c4Active {
 		return
 	}
 
-	// Handle forfeit
-	if r.Emoji.Name == "🏳️" {
-		c4HandleReactionForfeit(s, game, r.UserID)
+	c4RouteReactionIntent(s, game, r.UserID, r.Emoji.Name)
+}
+
+// HandleReactionRemove processes a reaction removed from a Connect 4 game
+// message. A removal counts as input too: when the bot's cleanup is lagging
+// (Discord rate-limits reaction deletes) a player's reaction lingers, so their
+// next tap on that column toggles it off, and that tap should still register.
+// Removals the bot performed itself are swallowed so they don't replay as moves.
+func HandleReactionRemove(s *discordgo.Session, r *discordgo.MessageReactionRemove) {
+	if r.UserID == s.State.User.ID {
 		return
 	}
 
-	// Determine column from emoji
-	col := -1
+	game := c4mgr.getGameByMessage(r.MessageID)
+	if game == nil {
+		return
+	}
+
+	// Swallow the removal the bot itself issued while cleaning up after a move.
+	if c4mgr.consumeSelfRemoval(r.MessageID, r.UserID, r.Emoji.APIName()) {
+		return
+	}
+
+	if game.Status != c4Active {
+		return
+	}
+
+	c4RouteReactionIntent(s, game, r.UserID, r.Emoji.Name)
+}
+
+// c4RouteReactionIntent interprets a reaction emoji as a forfeit or column move
+// for an active game. Shared by the add and remove handlers so either toggle
+// direction registers as the same input.
+func c4RouteReactionIntent(s *discordgo.Session, game *Connect4Game, userID, emojiName string) {
+	// Normalize away variation selectors: Discord doesn't reliably include
+	// U+FE0F on reaction payloads, which otherwise breaks emoji matching.
+	name := c4NormalizeEmoji(emojiName)
+
+	if name == c4NormalizeEmoji(c4EmojiForfeit) {
+		c4HandleReactionForfeit(s, game, userID)
+		return
+	}
+
 	for i, emoji := range c4ColumnEmoji {
-		if r.Emoji.Name == emoji {
-			col = i
-			break
+		if name == c4NormalizeEmoji(emoji) {
+			c4HandleReactionMove(s, game, userID, i)
+			return
 		}
 	}
-	if col == -1 {
-		return
-	}
-
-	c4HandleReactionMove(s, game, r.UserID, col)
 }
 
 func c4HandleReactionMove(s *discordgo.Session, game *Connect4Game, userID string, col int) {
-	var player int
-	if userID == game.Player1 {
-		player = c4Player1
-	} else if userID == game.Player2 {
-		player = c4Player2
-	} else {
+	player := c4PlayerForUser(game, userID)
+	if player == c4Empty {
 		return // not a player
 	}
 
@@ -580,25 +700,28 @@ func c4HandleReactionMove(s *discordgo.Session, game *Connect4Game, userID strin
 		return // column full, just ignore
 	}
 
+	game.Moves++
 	game.LastActivity = time.Now()
 
-	if c4CheckWin(game, row, col, player) {
+	finished := true
+	switch {
+	case c4CheckWin(game, row, col, player):
 		game.Status = c4Finished
 		game.Winner = player
-	} else if c4CheckDraw(game) {
+	case c4CheckDraw(game):
 		game.Status = c4Finished
 		game.Winner = 0
-	} else {
-		if game.Turn == c4Player1 {
-			game.Turn = c4Player2
-		} else {
-			game.Turn = c4Player1
-		}
+	default:
+		game.Turn = c4Other(player)
+		finished = false
 	}
 
 	c4mgr.mu.Unlock()
 
 	c4mgr.updateGameMessage(game)
+	if finished {
+		c4ClearReactions(s, game)
+	}
 }
 
 func c4HandleReactionForfeit(s *discordgo.Session, game *Connect4Game, userID string) {
@@ -609,13 +732,14 @@ func c4HandleReactionForfeit(s *discordgo.Session, game *Connect4Game, userID st
 		return
 	}
 
-	if userID == game.Player1 {
+	switch userID {
+	case game.Player1:
 		game.Winner = c4Player2
-		game.WinReason = fmt.Sprintf("🏳️ <@%s> forfeited — %s <@%s> wins!", game.Player1, c4EmojiPlayer2, game.Player2)
-	} else if userID == game.Player2 {
+		game.WinReason = fmt.Sprintf("%s <@%s> forfeited - %s <@%s> wins!", c4EmojiForfeit, game.Player1, c4EmojiPlayer2, game.Player2)
+	case game.Player2:
 		game.Winner = c4Player1
-		game.WinReason = fmt.Sprintf("🏳️ <@%s> forfeited — %s <@%s> wins!", game.Player2, c4EmojiPlayer1, game.Player1)
-	} else {
+		game.WinReason = fmt.Sprintf("%s <@%s> forfeited - %s <@%s> wins!", c4EmojiForfeit, game.Player2, c4EmojiPlayer1, game.Player1)
+	default:
 		c4mgr.mu.Unlock()
 		return
 	}
@@ -625,9 +749,46 @@ func c4HandleReactionForfeit(s *discordgo.Session, game *Connect4Game, userID st
 	c4mgr.mu.Unlock()
 
 	c4mgr.updateGameMessage(game)
+	c4ClearReactions(s, game)
 }
 
 // --- Helpers ---
+
+// c4PlayerForUser maps a Discord user ID to its player number, or c4Empty if
+// the user isn't a participant in the game.
+func c4PlayerForUser(game *Connect4Game, userID string) int {
+	switch userID {
+	case game.Player1:
+		return c4Player1
+	case game.Player2:
+		return c4Player2
+	default:
+		return c4Empty
+	}
+}
+
+// c4Other returns the opposing player number.
+func c4Other(player int) int {
+	if player == c4Player1 {
+		return c4Player2
+	}
+	return c4Player1
+}
+
+// c4NormalizeEmoji strips Unicode variation selectors (U+FE0F) so reaction
+// matching works whether or not Discord includes them in the gateway payload.
+func c4NormalizeEmoji(emoji string) string {
+	return strings.ReplaceAll(emoji, "\uFE0F", "")
+}
+
+// c4ClearReactions best-effort removes every reaction from a finished game's
+// message so players can't keep clicking dead buttons. Requires Manage Messages.
+func c4ClearReactions(s *discordgo.Session, game *Connect4Game) {
+	if s == nil || game.MessageID == "" {
+		return
+	}
+	_ = s.MessageReactionsRemoveAll(game.ChannelID, game.MessageID)
+}
 
 func generateGameID() string {
 	b := make([]byte, 4)

--- a/internal/commands/modules/fun/connect4_test.go
+++ b/internal/commands/modules/fun/connect4_test.go
@@ -1,0 +1,353 @@
+package fun
+
+import (
+	"strings"
+	"sync"
+	"testing"
+)
+
+// newTestGame returns an active game with an empty board and no Discord wiring,
+// so updateGameMessage is a no-op (c4mgr.session is nil in tests).
+func newTestGame() *Connect4Game {
+	return &Connect4Game{
+		ID:      "test",
+		Player1: "p1",
+		Player2: "p2",
+		Turn:    c4Player1,
+		Status:  c4Active,
+	}
+}
+
+func TestC4DropPiece(t *testing.T) {
+	g := newTestGame()
+
+	// First drop in column 3 should land on the bottom row.
+	row := c4DropPiece(g, 3, c4Player1)
+	if row != c4Rows-1 {
+		t.Fatalf("first drop landed on row %d, want %d", row, c4Rows-1)
+	}
+
+	// Second drop should stack on top of the first.
+	row = c4DropPiece(g, 3, c4Player2)
+	if row != c4Rows-2 {
+		t.Fatalf("second drop landed on row %d, want %d", row, c4Rows-2)
+	}
+
+	// Fill the rest of the column; the next drop must report "full".
+	for r := c4Rows - 3; r >= 0; r-- {
+		if got := c4DropPiece(g, 3, c4Player1); got != r {
+			t.Fatalf("fill drop landed on row %d, want %d", got, r)
+		}
+	}
+	if got := c4DropPiece(g, 3, c4Player1); got != -1 {
+		t.Fatalf("drop on full column returned %d, want -1", got)
+	}
+}
+
+func TestC4CheckWinHorizontal(t *testing.T) {
+	g := newTestGame()
+	var lastRow, lastCol int
+	for c := 0; c < 4; c++ {
+		lastRow = c4DropPiece(g, c, c4Player1)
+		lastCol = c
+	}
+	if !c4CheckWin(g, lastRow, lastCol, c4Player1) {
+		t.Fatal("expected horizontal win")
+	}
+}
+
+func TestC4CheckWinVertical(t *testing.T) {
+	g := newTestGame()
+	var lastRow int
+	for i := 0; i < 4; i++ {
+		lastRow = c4DropPiece(g, 2, c4Player2)
+	}
+	if !c4CheckWin(g, lastRow, 2, c4Player2) {
+		t.Fatal("expected vertical win")
+	}
+}
+
+func TestC4CheckWinDiagonalUp(t *testing.T) {
+	// Build an ascending diagonal (/) for player 1.
+	g := newTestGame()
+	// Column heights needed for a diagonal at (5,0),(4,1),(3,2),(2,3).
+	layout := [][]int{
+		{c4Player1},                                  // col0: p1 at row5
+		{c4Player2, c4Player1},                       // col1: p1 at row4
+		{c4Player2, c4Player2, c4Player1},            // col2: p1 at row3
+		{c4Player2, c4Player2, c4Player2, c4Player1}, // col3: p1 at row2
+	}
+	var lr, lc int
+	for col, stack := range layout {
+		for _, p := range stack {
+			lr = c4DropPiece(g, col, p)
+			lc = col
+		}
+	}
+	if !c4CheckWin(g, lr, lc, c4Player1) {
+		t.Fatal("expected ascending diagonal win")
+	}
+}
+
+func TestC4CheckWinDiagonalDown(t *testing.T) {
+	// Build a descending diagonal (\) for player 1 at (2,0),(3,1),(4,2),(5,3).
+	g := newTestGame()
+	layout := [][]int{
+		{c4Player2, c4Player2, c4Player2, c4Player1}, // col0: p1 at row2
+		{c4Player2, c4Player2, c4Player1},            // col1: p1 at row3
+		{c4Player2, c4Player1},                       // col2: p1 at row4
+		{c4Player1},                                  // col3: p1 at row5
+	}
+	var lr, lc int
+	for col, stack := range layout {
+		for _, p := range stack {
+			lr = c4DropPiece(g, col, p)
+			lc = col
+		}
+	}
+	if !c4CheckWin(g, lr, lc, c4Player1) {
+		t.Fatal("expected descending diagonal win")
+	}
+}
+
+func TestC4CheckWinNegative(t *testing.T) {
+	g := newTestGame()
+	// Three in a row is not a win.
+	for c := 0; c < 3; c++ {
+		c4DropPiece(g, c, c4Player1)
+	}
+	if c4CheckWin(g, c4Rows-1, 2, c4Player1) {
+		t.Fatal("three in a row should not win")
+	}
+}
+
+func TestC4CheckDraw(t *testing.T) {
+	g := newTestGame()
+	if c4CheckDraw(g) {
+		t.Fatal("empty board is not a draw")
+	}
+	// Fill the board completely.
+	for col := 0; col < c4Cols; col++ {
+		for row := 0; row < c4Rows; row++ {
+			g.Board[row][col] = c4Player1
+		}
+	}
+	if !c4CheckDraw(g) {
+		t.Fatal("full board should be a draw")
+	}
+}
+
+func TestC4MoveTurnEnforcement(t *testing.T) {
+	g := newTestGame()
+	// Player 2 cannot move on player 1's turn.
+	c4HandleReactionMove(nil, g, "p2", 0)
+	if g.Board[c4Rows-1][0] != c4Empty {
+		t.Fatal("out-of-turn move should be ignored")
+	}
+	// Player 1 moves; turn passes to player 2.
+	c4HandleReactionMove(nil, g, "p1", 0)
+	if g.Board[c4Rows-1][0] != c4Player1 {
+		t.Fatal("player 1 move did not register")
+	}
+	if g.Turn != c4Player2 {
+		t.Fatalf("turn did not pass to player 2, got %d", g.Turn)
+	}
+}
+
+func TestC4MoveNonPlayerIgnored(t *testing.T) {
+	g := newTestGame()
+	c4HandleReactionMove(nil, g, "stranger", 0)
+	if g.Board[c4Rows-1][0] != c4Empty {
+		t.Fatal("non-player move should be ignored")
+	}
+}
+
+func TestC4MoveWinFinishesGame(t *testing.T) {
+	g := newTestGame()
+	// p1 and p2 alternate; p1 builds a vertical four in column 0.
+	moves := []struct {
+		user string
+		col  int
+	}{
+		{"p1", 0}, {"p2", 1},
+		{"p1", 0}, {"p2", 1},
+		{"p1", 0}, {"p2", 1},
+		{"p1", 0}, // winning move
+	}
+	for _, m := range moves {
+		c4HandleReactionMove(nil, g, m.user, m.col)
+	}
+	if g.Status != c4Finished {
+		t.Fatalf("game should be finished after a win, status=%d", g.Status)
+	}
+	if g.Winner != c4Player1 {
+		t.Fatalf("winner should be player 1, got %d", g.Winner)
+	}
+}
+
+// TestC4ConcurrentMoves hammers a game from multiple goroutines to surface data
+// races under `go test -race`. Both players spam every column at once.
+func TestC4ConcurrentMoves(t *testing.T) {
+	g := newTestGame()
+	var wg sync.WaitGroup
+	for iter := 0; iter < 50; iter++ {
+		for _, user := range []string{"p1", "p2"} {
+			for col := 0; col < c4Cols; col++ {
+				wg.Add(1)
+				go func(u string, c int) {
+					defer wg.Done()
+					c4HandleReactionMove(nil, g, u, c)
+				}(user, col)
+			}
+		}
+	}
+	wg.Wait()
+}
+
+func TestC4FinishedEmbedHidesEmptyBoard(t *testing.T) {
+	// A declined challenge: finished, no moves played -> no board grid.
+	g := newTestGame()
+	g.Status = c4Finished
+	g.Moves = 0
+	g.WinReason = "❌ <@p1> cancelled the challenge."
+	if got := c4BuildGameEmbed(g).Description; strings.Contains(got, c4EmojiEmpty) {
+		t.Fatalf("declined game should not render an empty board, got:\n%s", got)
+	}
+
+	// A played-out game should still render the board.
+	g2 := newTestGame()
+	g2.Status = c4Finished
+	g2.Moves = 1
+	g2.Board[c4Rows-1][0] = c4Player1
+	if got := c4BuildGameEmbed(g2).Description; !strings.Contains(got, c4EmojiEmpty) {
+		t.Fatalf("played game should render the board, got:\n%s", got)
+	}
+}
+
+func TestC4NormalizeEmoji(t *testing.T) {
+	// Flag with and without the variation selector must compare equal.
+	withVS := "\U0001F3F3\uFE0F"
+	withoutVS := "\U0001F3F3"
+	if c4NormalizeEmoji(withVS) != c4NormalizeEmoji(withoutVS) {
+		t.Fatal("forfeit emoji should match regardless of variation selector")
+	}
+	// Keycaps normalize consistently too.
+	if c4NormalizeEmoji("1\uFE0F\u20E3") != c4NormalizeEmoji("1\u20E3") {
+		t.Fatal("keycap emoji should match regardless of variation selector")
+	}
+}
+
+func TestC4Other(t *testing.T) {
+	if c4Other(c4Player1) != c4Player2 || c4Other(c4Player2) != c4Player1 {
+		t.Fatal("c4Other should return the opposing player")
+	}
+}
+
+func TestC4RouteReactionIntentColumnMove(t *testing.T) {
+	g := newTestGame()
+	c4RouteReactionIntent(nil, g, "p1", c4ColumnEmoji[0])
+	if g.Board[c4Rows-1][0] != c4Player1 {
+		t.Fatal("a column reaction should drop a piece for the player")
+	}
+}
+
+func TestC4RouteReactionIntentForfeit(t *testing.T) {
+	g := newTestGame()
+	c4RouteReactionIntent(nil, g, "p1", c4EmojiForfeit)
+	if g.Status != c4Finished || g.Winner != c4Player2 {
+		t.Fatalf("forfeit reaction should finish the game for the opponent, status=%d winner=%d", g.Status, g.Winner)
+	}
+}
+
+// TestC4SelfRemovalSuppression locks in the bookkeeping that lets the remove
+// handler tell its own cleanup removal apart from a player toggling a reaction
+// off: an unknown removal is real input, a marked one is swallowed exactly once.
+func TestC4SelfRemovalSuppression(t *testing.T) {
+	msg, user, emoji := "msg-suppress", "userA", c4ColumnEmoji[2]
+
+	if c4mgr.consumeSelfRemoval(msg, user, emoji) {
+		t.Fatal("a removal with no pending token should not be suppressed")
+	}
+
+	c4mgr.markSelfRemoval(msg, user, emoji)
+	if !c4mgr.consumeSelfRemoval(msg, user, emoji) {
+		t.Fatal("the bot's own removal should be suppressed once")
+	}
+	if c4mgr.consumeSelfRemoval(msg, user, emoji) {
+		t.Fatal("a second removal should no longer be suppressed")
+	}
+}
+
+func TestC4SelfRemovalUnmark(t *testing.T) {
+	msg, user, emoji := "msg-unmark", "userB", c4ColumnEmoji[3]
+	c4mgr.markSelfRemoval(msg, user, emoji)
+	c4mgr.unmarkSelfRemoval(msg, user, emoji)
+	if c4mgr.consumeSelfRemoval(msg, user, emoji) {
+		t.Fatal("an unmarked token should not suppress a later removal")
+	}
+}
+
+func TestC4RemovalKeyNormalizesVariationSelector(t *testing.T) {
+	withVS := c4RemovalKey("m", "u", "\U0001F3F3\uFE0F")
+	withoutVS := c4RemovalKey("m", "u", "\U0001F3F3")
+	if withVS != withoutVS {
+		t.Fatal("removal key should match regardless of variation selector")
+	}
+}
+
+func TestC4PurgePendingRemovals(t *testing.T) {
+	msg := "msg-purge"
+	c4mgr.markSelfRemoval(msg, "u1", c4ColumnEmoji[0])
+	c4mgr.markSelfRemoval(msg, "u2", c4ColumnEmoji[1])
+
+	c4mgr.mu.Lock()
+	c4mgr.purgePendingRemovalsLocked(msg)
+	c4mgr.mu.Unlock()
+
+	if c4mgr.consumeSelfRemoval(msg, "u1", c4ColumnEmoji[0]) || c4mgr.consumeSelfRemoval(msg, "u2", c4ColumnEmoji[1]) {
+		t.Fatal("purged tokens should no longer suppress removals")
+	}
+}
+
+// TestC4SelfRemovalConcurrent exercises the token map from many goroutines so
+// `go test -race` can catch unsynchronized access.
+func TestC4SelfRemovalConcurrent(t *testing.T) {
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			emoji := c4ColumnEmoji[n%c4Cols]
+			c4mgr.markSelfRemoval("cmsg", "cuser", emoji)
+			c4mgr.consumeSelfRemoval("cmsg", "cuser", emoji)
+		}(i)
+	}
+	wg.Wait()
+}
+
+func TestC4MoveDrawFinishesGame(t *testing.T) {
+	g := newTestGame()
+	// Fill the whole board, then empty the top-left cell so exactly one legal
+	// move remains. Surround that cell so the final piece completes no line:
+	// the draw path is what's under test, not board realism.
+	for col := 0; col < c4Cols; col++ {
+		for row := 0; row < c4Rows; row++ {
+			g.Board[row][col] = c4Player2
+		}
+	}
+	g.Board[0][0] = c4Empty // the only open slot, lands at row 0
+	g.Moves = c4Rows*c4Cols - 1
+	g.Turn = c4Player1
+
+	c4HandleReactionMove(nil, g, "p1", 0)
+
+	if g.Board[0][0] != c4Player1 {
+		t.Fatal("final move did not register")
+	}
+	if g.Status != c4Finished {
+		t.Fatalf("full board should finish the game, status=%d", g.Status)
+	}
+	if g.Winner != 0 {
+		t.Fatalf("a filled board with no completed line should be a draw, winner=%d", g.Winner)
+	}
+}


### PR DESCRIPTION
Moves occasionally did not register: reaction input only listened for adds, and Discord rate-limits the per-move reaction cleanup, so a lingering reaction turned the next tap into an ignored remove. Now removes count too (toggling a reaction off still registers), and the bot suppresses its own cleanup removals so they don't replay as phantom moves.

Also in here:
- Fix a data race that rendered the board during a concurrent move.
- Stop rendering an empty grid on declined or timed-out challenges.
- Harden emoji matching against missing variation selectors.
- Add tests for game logic, concurrency, and the removal bookkeeping.

Known residual: if the bot's cleanup of a column is still in flight when a player re-taps that same column, that one toggle-off is swallowed and they tap once more. It recovers on the next tap, and the no-Manage-Messages case now registers every tap.